### PR TITLE
docs: add development governance structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # money-control
+
+## Development Governance
+
+The repository now includes a lightweight governance structure for development work with English and Portuguese entry points in [docs/governance/README.md](/home/nal/code/BernardoNal/money-control/docs/governance/README.md).

--- a/docs/governance/README.en.md
+++ b/docs/governance/README.en.md
@@ -1,0 +1,22 @@
+# Governance
+
+This directory centralizes the project's development governance.
+
+Use these files before any code change:
+
+- `development-workflow.md`: mandatory workflow for analysis, planning, approval, implementation, review, and delivery
+- `agents/`: role definitions for the development agents
+- `templates/`: reusable templates for issue creation, implementation planning, and pull requests
+
+Recommended order:
+
+1. Open the issue template.
+2. Fill the implementation plan.
+3. Create a branch using the documented naming convention.
+4. Execute the change only after explicit approval.
+5. Close the work with the PR template and final checklist.
+
+Language:
+
+- [Português](</home/nal/code/BernardoNal/money-control/docs/governance/README.pt-BR.md>)
+- [Back to selector](</home/nal/code/BernardoNal/money-control/docs/governance/README.md>)

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,0 +1,6 @@
+# Governance
+
+Choose a language:
+
+- [English](</home/nal/code/BernardoNal/money-control/docs/governance/README.en.md>)
+- [Português](</home/nal/code/BernardoNal/money-control/docs/governance/README.pt-BR.md>)

--- a/docs/governance/README.pt-BR.md
+++ b/docs/governance/README.pt-BR.md
@@ -1,0 +1,22 @@
+# Governança
+
+Este diretório centraliza a governança de desenvolvimento do projeto.
+
+Use estes arquivos antes de qualquer alteração de código:
+
+- `development-workflow.md`: fluxo obrigatório para análise, planejamento, aprovação, implementação, revisão e entrega
+- `agents/`: definição dos papéis dos agentes de desenvolvimento
+- `templates/`: modelos reutilizáveis para criação de issue, plano de implementação e pull request
+
+Ordem recomendada:
+
+1. Abrir o template de issue.
+2. Preencher o plano de implementação.
+3. Criar uma branch usando a convenção documentada.
+4. Executar a alteração somente após aprovação explícita.
+5. Encerrar o trabalho com o template de PR e o checklist final.
+
+Idioma:
+
+- [English](</home/nal/code/BernardoNal/money-control/docs/governance/README.en.md>)
+- [Voltar ao seletor](</home/nal/code/BernardoNal/money-control/docs/governance/README.md>)

--- a/docs/governance/agents/backend-agent.md
+++ b/docs/governance/agents/backend-agent.md
@@ -1,0 +1,28 @@
+# Backend Agent
+
+## Purpose
+
+Own backend implementation quality for Rails code changes.
+
+## Responsibilities
+
+- keep controllers, models, routes, and services cohesive
+- preserve Rails conventions
+- avoid unnecessary coupling
+- validate parameter handling and model relationships
+- keep changes scoped to the requested feature or fix
+
+## Required Checks
+
+- no unscoped queries for user-owned data
+- no unauthorized record lookup
+- routes and redirects are valid
+- validations and associations match the feature
+- business rules stay out of views when possible
+
+## Deliverables
+
+- implementation notes
+- changed files list
+- test status
+- known risks or follow-up items

--- a/docs/governance/agents/review-agent.md
+++ b/docs/governance/agents/review-agent.md
@@ -1,0 +1,27 @@
+# Review Agent
+
+## Purpose
+
+Close the loop before delivery with a structured review of quality and readiness.
+
+## Responsibilities
+
+- verify the implementation matches the approved plan
+- confirm tests and evidence are present
+- review architecture, frontend, and regression risk
+- ensure the final checklist is complete
+- prepare the PR summary in a clean, traceable format
+
+## Required Checks
+
+- approved scope matches delivered scope
+- tests were executed or gaps are explicitly stated
+- references to issues, branches, and files are consistent
+- no broken route, template, or obvious regression remains
+- PR text clearly communicates what changed and why
+
+## Deliverables
+
+- review notes
+- final checklist status
+- PR-ready summary

--- a/docs/governance/agents/security-agent.md
+++ b/docs/governance/agents/security-agent.md
@@ -1,0 +1,27 @@
+# Security Agent
+
+## Purpose
+
+Review changes for authorization, exposure, and unsafe data handling.
+
+## Responsibilities
+
+- verify scoping by authenticated user
+- review mass assignment surfaces
+- inspect destructive actions and authorization paths
+- watch for secret exposure or unsafe configuration
+- flag cross-user access risks
+
+## Required Checks
+
+- access is limited to the correct user scope
+- no `find` bypasses authorization for protected records
+- sensitive fields are not trusted from request params
+- no credential, token, or secret is committed
+- destructive flows include appropriate confirmation and guardrails
+
+## Deliverables
+
+- security findings
+- residual risk notes
+- approval or required fixes

--- a/docs/governance/development-workflow.md
+++ b/docs/governance/development-workflow.md
@@ -1,0 +1,183 @@
+# Development Workflow
+
+This workflow is mandatory for every project change.
+
+## 1. Branch
+
+Never work directly on `main`, `master`, or `production`.
+
+Create a dedicated branch first:
+
+- `feature/name`
+- `fix/name`
+- `refactor/name`
+- `hotfix/name`
+
+Examples:
+
+- `feature/investments-module`
+- `fix/account-update-bug`
+- `refactor/transactions-domain`
+
+## 2. Analysis
+
+Before implementation, review the impact on:
+
+- architecture
+- database
+- security
+- performance
+- tests
+- compatibility
+
+## 3. Implementation Plan
+
+The plan must contain:
+
+- objective
+- affected files
+- risks
+- technical strategy
+- database impact
+- required tests
+
+## 4. Approval
+
+Implementation only starts after explicit approval.
+
+Flow:
+
+1. Analysis
+2. Plan
+3. Approval
+4. Implementation
+
+## 5. Execution Follow-Up
+
+For longer changes, keep progress visible:
+
+- what is done
+- what is in progress
+- what is left
+- blockers or risks
+- strategy changes
+
+## 6. Mandatory Review
+
+After implementation, review:
+
+### Architecture
+
+- organization
+- coupling
+- class responsibilities
+
+### Security
+
+- user scoping
+- authorization
+- data leaks
+- mass assignment
+
+### Performance
+
+- queries
+- N+1
+- eager loading
+- unnecessary queries
+
+### Database
+
+- indexes
+- foreign keys
+- constraints
+- nullable mistakes
+
+### Rails Quality
+
+- Rails conventions
+- method names
+- cohesion
+- single responsibility
+
+### Frontend
+
+- responsiveness
+- visual consistency
+- Turbo and Hotwire behavior
+- accessibility
+
+### Tests
+
+- broken specs
+- coverage
+- regressions
+- factories or fixtures
+- Devise authentication
+
+## 7. Final Checklist
+
+Every delivery must validate:
+
+- [ ] All tests passed
+- [ ] No broken routes
+- [ ] No invalid references
+- [ ] No unsafe queries
+- [ ] No unscoped `Model.all`
+- [ ] No unauthorized `find`
+- [ ] No old migration changed
+- [ ] No secret exposed
+- [ ] No critical warning left
+- [ ] Code follows the project standard
+
+## 8. Pull Request
+
+Every delivery must include:
+
+- summary
+- motivation
+- main changes
+- impacts
+- evidence
+
+Evidence may include:
+
+- screenshots
+- logs
+- test results
+
+## 9. Continuous Refactoring
+
+When touching a module:
+
+- fix nearby inconsistencies
+- remove dead code
+- improve poor names
+- improve local organization
+- reduce small technical debt
+
+Do not expand into large unrelated refactors.
+
+## 10. Operating Principles
+
+Prioritize:
+
+- predictability
+- traceability
+- security
+- future maintenance
+- scalability
+- clarity
+- simplicity
+
+Speed must never compromise architecture.
+
+## 11. Completion Rule
+
+No change is complete without:
+
+- final review
+- tests
+- architectural validation
+- security validation
+- complete functional confirmation

--- a/docs/governance/templates/implementation-plan-template.md
+++ b/docs/governance/templates/implementation-plan-template.md
@@ -1,0 +1,35 @@
+# Implementation Plan Template
+
+## Objective
+
+Describe what will be implemented.
+
+## Affected Files
+
+- file or area 1
+- file or area 2
+
+## Risks
+
+- risk 1
+- risk 2
+
+## Technical Strategy
+
+Describe how the change will be implemented.
+
+## Database Impact
+
+State whether migrations or schema changes are needed.
+
+## Required Tests
+
+- model specs
+- request specs
+- system validation
+
+## Approval
+
+- status:
+- approved by:
+- approval date:

--- a/docs/governance/templates/issue-template.md
+++ b/docs/governance/templates/issue-template.md
@@ -1,0 +1,38 @@
+# Issue Template
+
+## Title
+
+Short action-oriented title.
+
+Example:
+
+`Fix account update flow`
+
+## Context
+
+What is happening today and why it matters.
+
+## Objective
+
+What this task must deliver.
+
+## Acceptance Criteria
+
+- criterion 1
+- criterion 2
+- criterion 3
+
+## Impact Review
+
+- architecture:
+- database:
+- security:
+- performance:
+- tests:
+- compatibility:
+
+## Notes
+
+- related links:
+- dependencies:
+- out of scope:

--- a/docs/governance/templates/pr-template.md
+++ b/docs/governance/templates/pr-template.md
@@ -1,0 +1,38 @@
+# Pull Request Template
+
+## Summary
+
+What was implemented.
+
+## Motivation
+
+Why this change was necessary.
+
+## Main Changes
+
+- change 1
+- change 2
+- change 3
+
+## Impacts
+
+- architecture:
+- database:
+- security:
+- performance:
+- tests:
+- ui:
+
+## Evidence
+
+- screenshots:
+- logs:
+- test results:
+
+## Checklist
+
+- [ ] Tests passed
+- [ ] Routes checked
+- [ ] References checked
+- [ ] Security review completed
+- [ ] No critical warnings remain


### PR DESCRIPTION
## Summary
Adds a lightweight development governance structure to the repository.

## Motivation
Standardize analysis, planning, approval, implementation, review, and delivery without turning governance into a product feature.

## Main Changes
- adds `docs/governance` as the entry point for development governance
- documents the mandatory workflow for changes
- defines initial `backend`, `security`, and `review` agents
- adds reusable issue, implementation plan, and PR templates
- adds English and Portuguese governance README entry points
- updates the root `README.md` to point to the governance docs

## Impacts
- architecture: no application architecture change
- database: none
- security: no runtime impact; documentation now formalizes security checks
- performance: none
- tests: not applicable for docs-only change
- ui: none

## Evidence
- branch created: `feature/development-governance-structure`
- commit: `fe35193`
- branch pushed to `origin`
- documentation added under `docs/governance/`

## Checklist
- [x] Scope matches approved documentation-only change
- [x] No migrations changed
- [x] No runtime code paths changed
- [x] No secrets exposed
- [x] Final review completed
- [ ] Automated tests run
