### PR TITLE
fix: correct account update flow

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -30,15 +30,11 @@ class AccountsController < ApplicationController
   end
 
   def update
-    # @user = current_user
-     @user = User.first
-    @account = Account.new(account_params)
-    @account.user = @user
-    if @account.save
+    if @account.update(account_params)
       redirect_to account_path(@account)
       flash[:alert] = "Conta alterada com sucesso."
     else
-      render :edit, status: :unprocessable_entity
+      render :form, status: :unprocessable_entity
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
 require 'rspec/rails'
+require 'devise'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -65,6 +66,7 @@ RSpec.configure do |config|
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
+  config.include Devise::Test::IntegrationHelpers, type: :request
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -1,32 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe "Accounts", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/accounts/index"
-      expect(response).to have_http_status(:success)
-    end
+  let(:user) do
+    User.create!(
+      name: "Test User",
+      email: "user@example.com",
+      password: "password123"
+    )
   end
 
-  describe "GET /show" do
-    it "returns http success" do
-      get "/accounts/show"
-      expect(response).to have_http_status(:success)
-    end
+  let!(:account) do
+    Account.create!(
+      user: user,
+      name: "Principal",
+      bank: "Nubank",
+      initial_balance: 100.0,
+      limit: 500.0,
+      last_digits: "1234",
+      due_day: Date.current
+    )
   end
 
-  describe "GET /new" do
-    it "returns http success" do
-      get "/accounts/new"
-      expect(response).to have_http_status(:success)
-    end
+  before do
+    sign_in user
   end
 
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/accounts/edit"
-      expect(response).to have_http_status(:success)
+  describe "PATCH /update" do
+    it "updates the existing account without creating a new record" do
+      expect do
+        patch account_path(account), params: {
+          account: {
+            name: "Reserva",
+            bank: "Inter",
+            initial_balance: 250.0
+          }
+        }
+      end.not_to change(Account, :count)
+
+      expect(response).to redirect_to(account_path(account))
+
+      account.reload
+      expect(account.name).to eq("Reserva")
+      expect(account.bank).to eq("Inter")
+      expect(account.initial_balance.to_f).to eq(250.0)
+    end
+
+    it "renders edit when the update is invalid" do
+      patch account_path(account), params: {
+        account: {
+          name: "",
+          bank: "",
+          initial_balance: ""
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      account.reload
+      expect(account.name).to eq("Principal")
+      expect(account.bank).to eq("Nubank")
     end
   end
-
 end


### PR DESCRIPTION
## Summary
Fixes the account update flow so editing an account updates the existing record instead of creating a new one.

## Motivation
The current `update` action creates a new `Account` record with `.new` and `save`, which duplicates records instead of updating the loaded resource.

Closes #21

## Main Changes
- replaces `Account.new(...).save` with `@account.update(account_params)` in `AccountsController#update`
- renders the shared `form` template on invalid update instead of the missing `edit` template
- enables Devise integration helpers for request specs
- replaces generated account request specs with real update flow coverage

## Impacts
- architecture: localized controller and request spec change
- database: none
- security: no new exposure introduced
- performance: none
- tests: added request coverage for successful and invalid update flows
- ui: invalid edit submissions now return the correct form response

## Evidence
- branch: `fix/21-account-update-flow`
- commit: `dc885c8`
- `bundle exec rspec spec/requests/accounts_spec.rb` => passed
- full suite still has pre-existing failures in categories and transactions request specs

## Checklist
- [x] Fix controller logic
- [x] Validate update flow manually through request specs
- [x] Add/update specs
- [ ] Full suite green
