### PR TITLE
fix: correct category update flow

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -30,13 +30,11 @@ class CategoriesController < ApplicationController
   end
 
   def update
-    @category = Category.new(category_params)
-    @category.user = @user
-    if @category.save
+    if @category.update(category_params)
       redirect_to category_path(@category)
       flash[:alert] = "Categoria alterada com sucesso."
     else
-      render :edit, status: :unprocessable_entity
+      render :form, status: :unprocessable_entity
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
 require 'rspec/rails'
+require 'devise'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -65,6 +66,7 @@ RSpec.configure do |config|
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
+  config.include Devise::Test::IntegrationHelpers, type: :request
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -1,32 +1,63 @@
 require 'rails_helper'
 
 RSpec.describe "Categories", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/categories/index"
-      expect(response).to have_http_status(:success)
-    end
+  let(:user) do
+    User.create!(
+      name: "Test User",
+      email: "categories@example.com",
+      password: "password123"
+    )
   end
 
-  describe "GET /show" do
-    it "returns http success" do
-      get "/categories/show"
-      expect(response).to have_http_status(:success)
-    end
+  let!(:category) do
+    Category.create!(
+      user: user,
+      name: "Alimentacao",
+      is_income: false,
+      icon: "🍔",
+      color: "#ff6600"
+    )
   end
 
-  describe "GET /new" do
-    it "returns http success" do
-      get "/categories/new"
-      expect(response).to have_http_status(:success)
-    end
+  before do
+    sign_in user
   end
 
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/categories/edit"
-      expect(response).to have_http_status(:success)
+  describe "PATCH /update" do
+    it "updates the existing category without creating a new record" do
+      expect do
+        patch category_path(category), params: {
+          category: {
+            name: "Mercado",
+            is_income: true,
+            icon: "💰",
+            color: "#00aa00"
+          }
+        }
+      end.not_to change(Category, :count)
+
+      expect(response).to redirect_to(category_path(category))
+
+      category.reload
+      expect(category.name).to eq("Mercado")
+      expect(category.is_income).to be(true)
+      expect(category.icon).to eq("💰")
+      expect(category.color).to eq("#00aa00")
+    end
+
+    it "renders form when the update is invalid" do
+      patch category_path(category), params: {
+        category: {
+          name: "",
+          color: "invalid-color"
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      category.reload
+      expect(category.name).to eq("Alimentacao")
+      expect(category.color).to eq("#ff6600")
     end
   end
-
 end


### PR DESCRIPTION
## Summary
Fixes the category update flow so editing a category updates the existing record instead of creating a new one.

## Motivation
The current update action creates a new Category record instead of updating the loaded resource, which can duplicate records and break the expected edit flow.

Closes #22

## Main Changes
- replaces `Category.new(...).save` with `@category.update(category_params)` in `CategoriesController#update`
- renders the shared `form` template on invalid update instead of the missing `edit` template
- enables Devise integration helpers for request specs
- replaces generated category request specs with real update flow coverage

## Impacts
- architecture: localized controller and request spec change
- database: none
- security: no new exposure introduced
- performance: none
- tests: adds request coverage for successful and invalid update flows
- ui: invalid edit submissions now return the correct form response

## Evidence
- branch: `fix/22-category-update-flow`
- commit: `d55e2b3`
- `bundle exec rspec spec/requests/categories_spec.rb` => passed
- full suite still has pre-existing failures in accounts and transactions request specs

## Checklist
- [x] Existing category is updated correctly
- [x] No duplicated categories are created
- [x] Specs covering update flow added
- [ ] Full suite green