### PR TITLE
fix: correct category destroy redirect

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -42,7 +42,7 @@ class CategoriesController < ApplicationController
     @category.destroy
     flash[:alert] = "Categoria excluída com sucesso."
 
-    redirect_to categorys_path()
+    redirect_to categories_path
   end
 
   private

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -60,4 +60,14 @@ RSpec.describe "Categories", type: :request do
       expect(category.color).to eq("#ff6600")
     end
   end
+
+  describe "DELETE /destroy" do
+    it "removes the category and redirects to categories index" do
+      expect do
+        delete category_path(category)
+      end.to change(Category, :count).by(-1)
+
+      expect(response).to redirect_to(categories_path)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Fixes the invalid redirect helper in the categories destroy flow.

## Motivation
The destroy action redirects to `categorys_path`, which is not a valid Rails route helper. This can raise a routing error after deleting a category.

Closes #23

## Main Changes
- replaces `categorys_path()` with `categories_path` in `CategoriesController#destroy`
- adds request coverage for `DELETE /categories/:id`
- verifies the category is deleted and the redirect points to the categories index

## Impacts
- architecture: localized controller and request spec change
- database: none
- security: no new exposure introduced
- performance: none
- tests: adds destroy-flow request coverage for categories
- ui: delete flow now redirects correctly after category removal

## Evidence
- branch: `fix/23-category-destroy-redirect`
- commit: `ac87f17`
- `bundle exec rspec spec/requests/categories_spec.rb` => passed
- full suite still has pre-existing failures in transactions request specs

## Checklist
- [x] Destroy action redirects correctly
- [x] No routing errors remain
- [ ] Full suite green