### PR TITLE
fix: add transaction validations

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -23,7 +23,7 @@ class TransactionsController < ApplicationController
       redirect_to transaction_path(@transaction)
       flash[:alert] = "Conta criada com sucesso."
     else
-      render :new, status: :unprocessable_entity
+      render :form, status: :unprocessable_entity
     end
   end
 
@@ -42,7 +42,7 @@ class TransactionsController < ApplicationController
       flash[:alert] = "Transação atualizada com sucesso."
       redirect_to transaction_path(@transaction)
     else
-      render :edit, status: :unprocessable_entity
+      render :form, status: :unprocessable_entity
     end
   end
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,4 +1,6 @@
 class Transaction < ApplicationRecord
   belongs_to :category
   belongs_to :account
+
+  validates :amount, :date, :description, presence: true
 end

--- a/app/views/transactions/form.html.erb
+++ b/app/views/transactions/form.html.erb
@@ -3,9 +3,19 @@
   <%= link_to transactions_path, class: 'bg-black text-white text-decoration-none p-2' do %>
     <i class='fa-solid fa-circle-left'></i>volta
   <% end %>
-  <h1 class="pb-3 text-center"><%= @transaction.persisted? ? 'Editar Conta' : 'Nova Conta' %></h1>
+  <h1 class="pb-3 text-center"><%= @transaction.persisted? ? 'Editar Transação' : 'Nova Transação' %></h1>
   <div class="mx-3">
     <%= form_with model: @transaction, local: true do |f| %>
+      <% if @transaction.errors.any? %>
+        <div class="mb-4 rounded-lg border border-red-300 bg-red-50 p-4 text-red-700">
+          <h2 class="font-semibold">Não foi possível salvar a transação:</h2>
+          <ul class="mt-2 list-disc pl-5">
+            <% @transaction.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
       <div class="grid grid-cols-3">
         <div class="mx-auto">
           <%= f.label :amount, "Valor", class: "block mb-2 text-sm font-medium text-gray-900 " %>

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,5 +1,79 @@
 require 'rails_helper'
 
 RSpec.describe Transaction, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) do
+    User.create!(
+      name: "Model User",
+      email: "transaction-model@example.com",
+      password: "password123"
+    )
+  end
+
+  let(:account) do
+    Account.create!(
+      user: user,
+      name: "Principal",
+      bank: "Nubank",
+      initial_balance: 100.0
+    )
+  end
+
+  let(:category) do
+    Category.create!(
+      user: user,
+      name: "Mercado",
+      is_income: false,
+      icon: "🛒",
+      color: "#ff6600"
+    )
+  end
+
+  subject(:transaction) do
+    described_class.new(
+      amount: 49.9,
+      date: Date.current,
+      description: "Compra do mes",
+      account: account,
+      category: category
+    )
+  end
+
+  it "is valid with required attributes" do
+    expect(transaction).to be_valid
+  end
+
+  it "is invalid without amount" do
+    transaction.amount = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:amount]).to include("can't be blank")
+  end
+
+  it "is invalid without date" do
+    transaction.date = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:date]).to include("can't be blank")
+  end
+
+  it "is invalid without description" do
+    transaction.description = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:description]).to include("can't be blank")
+  end
+
+  it "is invalid without account" do
+    transaction.account = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:account]).to include("must exist")
+  end
+
+  it "is invalid without category" do
+    transaction.category = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:category]).to include("must exist")
+  end
 end

--- a/spec/requests/transactions_spec.rb
+++ b/spec/requests/transactions_spec.rb
@@ -1,32 +1,70 @@
 require 'rails_helper'
 
 RSpec.describe "Transactions", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/transactions/index"
-      expect(response).to have_http_status(:success)
-    end
+  let(:user) do
+    User.create!(
+      name: "Request User",
+      email: "transaction-request@example.com",
+      password: "password123"
+    )
   end
 
-  describe "GET /show" do
-    it "returns http success" do
-      get "/transactions/show"
-      expect(response).to have_http_status(:success)
-    end
+  let!(:account) do
+    Account.create!(
+      user: user,
+      name: "Principal",
+      bank: "Nubank",
+      initial_balance: 100.0
+    )
   end
 
-  describe "GET /new" do
-    it "returns http success" do
-      get "/transactions/new"
-      expect(response).to have_http_status(:success)
-    end
+  let!(:category) do
+    Category.create!(
+      user: user,
+      name: "Mercado",
+      is_income: false,
+      icon: "🛒",
+      color: "#ff6600"
+    )
   end
 
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/transactions/edit"
-      expect(response).to have_http_status(:success)
-    end
+  before do
+    sign_in user
   end
 
+  describe "POST /create" do
+    it "does not persist an invalid transaction and displays validation errors" do
+      expect do
+        post transactions_path, params: {
+          transaction: {
+            amount: "",
+            description: "",
+            date: "",
+            category_id: category.id
+          }
+        }
+      end.not_to change(Transaction, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Nao foi possivel salvar a transacao").or include("Não foi possível salvar a transação")
+      expect(response.body).to include("Amount can")
+      expect(response.body).to include("Date can")
+      expect(response.body).to include("Description can")
+    end
+
+    it "persists a valid transaction" do
+      expect do
+        post transactions_path, params: {
+          transaction: {
+            amount: 89.9,
+            description: "Mercado do mes",
+            date: Date.current,
+            category_id: category.id
+          }
+        }
+      end.to change(Transaction, :count).by(1)
+
+      expect(response).to redirect_to(transaction_path(Transaction.last))
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Adds required validations to the Transaction model and surfaces validation errors in the transaction form.

## Motivation
Transactions were missing required model-level validations for key financial fields. This allowed invalid records to be built without consistent server-side protection, and the form did not clearly present validation feedback.

Closes #24

## Main Changes
- adds presence validations for `amount`, `date`, and `description` in `Transaction`
- keeps `account` and `category` enforced through `belongs_to`
- updates transaction create and update flows to render the shared `form` template on validation failure
- displays validation errors in the transaction form
- corrects the transaction form title to use `Transação`
- replaces pending transaction model and request specs with real coverage

## Impacts
- architecture: localized changes in transaction model, controller, form, and specs
- database: none
- security: improves data integrity without changing authorization rules
- performance: none
- tests: adds model and request coverage for invalid and valid transaction flows
- ui: validation errors are now visible to the user in the form

## Evidence
- branch: `fix/24-transaction-validations`
- commit: `f677196`
- `bundle exec rspec spec/models/transaction_spec.rb spec/requests/transactions_spec.rb` => passed
- `bundle exec rspec` => passed with `20 examples, 0 failures, 7 pending`

## Checklist
- [x] Add model validations
- [x] Add model specs
- [x] Validate form behavior
- [x] Invalid transactions cannot be persisted
- [ ] Pending specs removed from unrelated areas