### PR TITLE
Add global investments asset catalog

### DIFF
--- a/app/models/investments/asset.rb
+++ b/app/models/investments/asset.rb
@@ -1,0 +1,18 @@
+module Investments
+  class Asset < ApplicationRecord
+    # Assets are modeled as a global market catalog, not as user-owned records.
+    self.table_name = "investments_assets"
+
+    enum :category, {
+      stock: 0,
+      fii: 1,
+      etf: 2,
+      crypto: 3,
+      fixed_income: 4,
+      international: 5
+    }
+
+    validates :name, :symbol, :category, :currency, presence: true
+    validates :symbol, uniqueness: true
+  end
+end

--- a/db/migrate/20260521170556_create_investments_assets.rb
+++ b/db/migrate/20260521170556_create_investments_assets.rb
@@ -1,0 +1,15 @@
+class CreateInvestmentsAssets < ActiveRecord::Migration[7.1]
+  def change
+    create_table :investments_assets do |t|
+      t.string :name, null: false
+      t.string :symbol, null: false
+      t.integer :category, null: false
+      t.string :currency, null: false
+      t.boolean :active, null: false, default: true
+
+      t.timestamps
+    end
+
+    add_index :investments_assets, :symbol, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_21_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_21_170556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -37,6 +37,17 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_21_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_categories_on_user_id"
+  end
+
+  create_table "investments_assets", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "symbol", null: false
+    t.integer "category", null: false
+    t.string "currency", null: false
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["symbol"], name: "index_investments_assets_on_symbol", unique: true
   end
 
   create_table "investments_portfolios", force: :cascade do |t|

--- a/docs/code-overview.md
+++ b/docs/code-overview.md
@@ -14,6 +14,8 @@ Its goal is to help contributors understand where the main responsibilities live
   money movement records linked to accounts and categories
 - `app/models/investments/portfolio.rb`
   base structure for investment portfolios owned by a user
+- `app/models/investments/asset.rb`
+  global catalog of market assets used as a base for future investment features
 
 ## Authentication And User Scope
 

--- a/docs/governance/issue-35-implementation-plan.md
+++ b/docs/governance/issue-35-implementation-plan.md
@@ -1,0 +1,61 @@
+# Issue 35 Implementation Plan
+
+## Objective
+
+Create the base `Investments::Asset` model as a global catalog entity for investment assets.
+
+The model should support immutable or near-immutable market identifiers and classifications such as stocks, FIIs, ETFs, crypto, fixed income, and international assets.
+
+## Affected Files
+
+- `app/models/investments/asset.rb`
+- `db/migrate/*_create_investments_assets.rb`
+- `db/schema.rb`
+- `spec/models/investments/asset_spec.rb`
+- `docs/code-overview.md`
+
+## Risks
+
+- Choosing the wrong ownership model for assets
+- Creating a category structure that is hard to evolve later
+- Missing database constraints for fields that should behave like catalog identifiers
+
+## Technical Strategy
+
+Implement `Investments::Asset` as a namespaced Active Record model under the `Investments` domain.
+
+Treat assets as a global catalog instead of a user-owned resource, because identifiers and categories should follow market definitions rather than per-user customization.
+
+Use an enum for `category` and store a simple `currency` code plus an `active` flag.
+
+Add model validations for required attributes and uniqueness for `symbol`.
+
+## Database Impact
+
+Adds a new `investments_assets` table with:
+
+- `name`
+- `symbol`
+- `category`
+- `currency`
+- `active`
+- timestamps
+
+Expected constraints:
+
+- `symbol` unique index
+- `active` non-null with default `true`
+- required catalog fields as non-null where appropriate
+
+## Required Tests
+
+- model specs for required attributes
+- enum behavior coverage
+- symbol uniqueness validation
+- active default validation
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-05-21

--- a/spec/models/investments/asset_spec.rb
+++ b/spec/models/investments/asset_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe Investments::Asset, type: :model do
+  subject(:asset) do
+    described_class.new(
+      name: "Apple Inc.",
+      symbol: "AAPL",
+      category: :international,
+      currency: "USD"
+    )
+  end
+
+  it "is valid with required attributes" do
+    expect(asset).to be_valid
+  end
+
+  it "is invalid without a name" do
+    asset.name = nil
+
+    expect(asset).not_to be_valid
+    expect(asset.errors[:name]).to include("can't be blank")
+  end
+
+  it "is invalid without a symbol" do
+    asset.symbol = nil
+
+    expect(asset).not_to be_valid
+    expect(asset.errors[:symbol]).to include("can't be blank")
+  end
+
+  it "is invalid without a category" do
+    asset.category = nil
+
+    expect(asset).not_to be_valid
+    expect(asset.errors[:category]).to include("can't be blank")
+  end
+
+  it "is invalid without a currency" do
+    asset.currency = nil
+
+    expect(asset).not_to be_valid
+    expect(asset.errors[:currency]).to include("can't be blank")
+  end
+
+  it "does not allow duplicate symbols" do
+    described_class.create!(
+      name: "Apple Inc.",
+      symbol: "AAPL",
+      category: :international,
+      currency: "USD"
+    )
+
+    expect(asset).not_to be_valid
+    expect(asset.errors[:symbol]).to include("has already been taken")
+  end
+
+  it "defines the expected categories" do
+    expect(described_class.categories.keys).to contain_exactly(
+      "stock",
+      "fii",
+      "etf",
+      "crypto",
+      "fixed_income",
+      "international"
+    )
+  end
+
+  it "defaults active to true" do
+    asset.save!
+
+    expect(asset.active).to be(true)
+  end
+end


### PR DESCRIPTION
## Summary

Implements the base  model as a global catalog for investment assets.

## Motivation

Issue #35 requires the first asset entity so the investments domain can represent market instruments such as stocks, FIIs, ETFs, crypto, fixed income, and international assets.

## Main Changes

- add  model
- define enum categories for supported asset types
- add migration for 
- validate required catalog fields
- enforce unique 
- default  to 
- add model specs for validations, enum coverage, uniqueness, and default behavior
- update lightweight code overview documentation

## Impacts

- architecture: expands the  namespace with a reusable catalog entity
- database: adds  table with unique index on 
- security: low-risk change, no controller or user-owned access path introduced
- performance: low impact, simple catalog table with indexed symbol lookups
- tests: model coverage added for core rules
- ui: no UI change in this issue

## Evidence

- test results:
  - 
Investments::Asset
  is valid with required attributes
  is invalid without a name
  is invalid without a symbol
  is invalid without a category
  is invalid without a currency
  does not allow duplicate symbols
  defines the expected categories
  defaults active to true

Finished in 0.04464 seconds (files took 1.23 seconds to load)
8 examples, 0 failures
  - 

## Checklist

- [x] Tests passed
- [x] References checked
- [x] Security review completed
- [x] No critical warnings remain