### PR TITLE
Add investments transaction structure

### DIFF
--- a/app/models/investments/asset.rb
+++ b/app/models/investments/asset.rb
@@ -3,6 +3,8 @@ module Investments
     # Assets are modeled as a global market catalog, not as user-owned records.
     self.table_name = "investments_assets"
 
+    has_many :transactions, class_name: "Investments::Transaction", dependent: :restrict_with_exception
+
     enum :category, {
       stock: 0,
       fii: 1,

--- a/app/models/investments/portfolio.rb
+++ b/app/models/investments/portfolio.rb
@@ -4,6 +4,7 @@ module Investments
     self.table_name = "investments_portfolios"
 
     belongs_to :user
+    has_many :transactions, class_name: "Investments::Transaction", dependent: :destroy
 
     validates :name, presence: true, uniqueness: { scope: :user_id }
   end

--- a/app/models/investments/transaction.rb
+++ b/app/models/investments/transaction.rb
@@ -1,0 +1,31 @@
+module Investments
+  class Transaction < ApplicationRecord
+    self.table_name = "investments_transactions"
+
+    belongs_to :portfolio, class_name: "Investments::Portfolio"
+    belongs_to :asset, class_name: "Investments::Asset"
+
+    enum :transaction_type, {
+      buy: 0,
+      sell: 1,
+      transfer: 2,
+      split: 3,
+      reverse_split: 4
+    }, prefix: true
+
+    validates :transaction_type, :quantity, :date, presence: true
+    validates :quantity, numericality: { greater_than: 0 }
+    validates :fees, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+    validates :price, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+    validate :price_required_for_market_trade
+
+    private
+
+    def price_required_for_market_trade
+      return unless transaction_type_buy? || transaction_type_sell?
+      return if price.present?
+
+      errors.add(:price, "can't be blank")
+    end
+  end
+end

--- a/db/migrate/20260524223202_create_investments_transactions.rb
+++ b/db/migrate/20260524223202_create_investments_transactions.rb
@@ -1,0 +1,18 @@
+class CreateInvestmentsTransactions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :investments_transactions do |t|
+      t.references :portfolio, null: false, foreign_key: { to_table: :investments_portfolios }
+      t.references :asset, null: false, foreign_key: { to_table: :investments_assets }
+      t.integer :transaction_type, null: false
+      t.decimal :quantity, null: false, precision: 15, scale: 8
+      t.decimal :price, precision: 15, scale: 4
+      t.decimal :fees, precision: 15, scale: 4, default: 0, null: false
+      t.date :date, null: false
+      t.text :notes
+
+      t.timestamps
+    end
+
+    add_index :investments_transactions, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_21_170556) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_24_223202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,6 +59,22 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_21_170556) do
     t.index ["user_id"], name: "index_investments_portfolios_on_user_id"
   end
 
+  create_table "investments_transactions", force: :cascade do |t|
+    t.bigint "portfolio_id", null: false
+    t.bigint "asset_id", null: false
+    t.integer "transaction_type", null: false
+    t.decimal "quantity", precision: 15, scale: 8, null: false
+    t.decimal "price", precision: 15, scale: 4
+    t.decimal "fees", precision: 15, scale: 4, default: "0.0", null: false
+    t.date "date", null: false
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["asset_id"], name: "index_investments_transactions_on_asset_id"
+    t.index ["date"], name: "index_investments_transactions_on_date"
+    t.index ["portfolio_id"], name: "index_investments_transactions_on_portfolio_id"
+  end
+
   create_table "transactions", force: :cascade do |t|
     t.decimal "amount"
     t.string "description"
@@ -90,6 +106,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_21_170556) do
   add_foreign_key "accounts", "users"
   add_foreign_key "categories", "users"
   add_foreign_key "investments_portfolios", "users"
+  add_foreign_key "investments_transactions", "investments_assets", column: "asset_id"
+  add_foreign_key "investments_transactions", "investments_portfolios", column: "portfolio_id"
   add_foreign_key "transactions", "accounts"
   add_foreign_key "transactions", "categories"
 end

--- a/docs/code-overview.md
+++ b/docs/code-overview.md
@@ -16,6 +16,8 @@ Its goal is to help contributors understand where the main responsibilities live
   base structure for investment portfolios owned by a user
 - `app/models/investments/asset.rb`
   global catalog of market assets used as a base for future investment features
+- `app/models/investments/transaction.rb`
+  operation history connecting user portfolios to global investment assets
 
 ## Authentication And User Scope
 

--- a/docs/governance/issue-36-implementation-plan.md
+++ b/docs/governance/issue-36-implementation-plan.md
@@ -1,0 +1,76 @@
+# Issue 36 Implementation Plan
+
+## Objective
+
+Implement the base `Investments::Transaction` model to represent investment operation history between user portfolios and global assets.
+
+Supported operations:
+
+- buy
+- sell
+- transfer
+- split
+- reverse split
+
+## Affected Files
+
+- `app/models/investments/transaction.rb`
+- `app/models/investments/portfolio.rb`
+- `app/models/investments/asset.rb`
+- `db/migrate/*_create_investments_transactions.rb`
+- `db/schema.rb`
+- `spec/models/investments/transaction_spec.rb`
+- `docs/code-overview.md`
+
+## Risks
+
+- Modeling price rules too strictly or too loosely for different transaction types
+- Forgetting ownership boundaries where transactions belong to user portfolios but assets are global
+- Missing indexes for historical lookup by portfolio, asset, or date
+
+## Technical Strategy
+
+Implement `Investments::Transaction` as a namespaced model linked to:
+
+- `Investments::Portfolio` as a user-owned container
+- `Investments::Asset` as a global catalog record
+
+Use an enum for `transaction_type`.
+
+Add validations for required data, quantity, fees, and conditional price presence for market trades.
+
+Keep the scope at the model/database layer for this issue, without introducing CRUD yet.
+
+## Database Impact
+
+Adds a new `investments_transactions` table with:
+
+- `portfolio_id`
+- `asset_id`
+- `transaction_type`
+- `quantity`
+- `price`
+- `fees`
+- `date`
+- `notes`
+- timestamps
+
+Expected constraints:
+
+- foreign keys to portfolios and assets
+- required fields as non-null where appropriate
+- indexes for portfolio, asset, and date lookups
+
+## Required Tests
+
+- model specs for associations
+- enum behavior coverage
+- presence validations
+- numeric validations
+- conditional price validation by transaction type
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-05-24

--- a/spec/models/investments/transaction_spec.rb
+++ b/spec/models/investments/transaction_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe Investments::Transaction, type: :model do
+  let(:user) do
+    User.create!(
+      name: "Investor",
+      email: "transaction-investor@example.com",
+      password: "password123"
+    )
+  end
+
+  let(:portfolio) do
+    Investments::Portfolio.create!(
+      user: user,
+      name: "Main Portfolio"
+    )
+  end
+
+  let(:asset) do
+    Investments::Asset.create!(
+      name: "Bitcoin",
+      symbol: "BTC",
+      category: :crypto,
+      currency: "USD"
+    )
+  end
+
+  subject(:transaction) do
+    described_class.new(
+      portfolio: portfolio,
+      asset: asset,
+      transaction_type: :buy,
+      quantity: 0.5,
+      price: 250000.0,
+      fees: 25.0,
+      date: Date.current,
+      notes: "Initial position"
+    )
+  end
+
+  it "is valid with required attributes" do
+    expect(transaction).to be_valid
+  end
+
+  it "belongs to a portfolio" do
+    transaction.portfolio = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:portfolio]).to include("must exist")
+  end
+
+  it "belongs to an asset" do
+    transaction.asset = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:asset]).to include("must exist")
+  end
+
+  it "is invalid without a transaction type" do
+    transaction.transaction_type = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:transaction_type]).to include("can't be blank")
+  end
+
+  it "is invalid without a quantity" do
+    transaction.quantity = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:quantity]).to include("can't be blank")
+  end
+
+  it "is invalid when quantity is zero" do
+    transaction.quantity = 0
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:quantity]).to include("must be greater than 0")
+  end
+
+  it "is invalid without a date" do
+    transaction.date = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:date]).to include("can't be blank")
+  end
+
+  it "requires price for buy transactions" do
+    transaction.price = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:price]).to include("can't be blank")
+  end
+
+  it "requires price for sell transactions" do
+    transaction.transaction_type = :sell
+    transaction.price = nil
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:price]).to include("can't be blank")
+  end
+
+  it "allows missing price for split transactions" do
+    transaction.transaction_type = :split
+    transaction.price = nil
+
+    expect(transaction).to be_valid
+  end
+
+  it "is invalid when fees are negative" do
+    transaction.fees = -1
+
+    expect(transaction).not_to be_valid
+    expect(transaction.errors[:fees]).to include("must be greater than or equal to 0")
+  end
+
+  it "defines the expected transaction types" do
+    expect(described_class.transaction_types.keys).to contain_exactly(
+      "buy",
+      "sell",
+      "transfer",
+      "split",
+      "reverse_split"
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Implements the base Investments::Transaction model to represent investment operation history between user portfolios and global assets.

## Motivation

Issue #36 requires the first transaction structure for the investments domain so portfolios can record operations such as buy, sell, transfer, split, and reverse split.

## Main Changes

- add Investments::Transaction model
- link transactions to Investments::Portfolio and Investments::Asset
- define enum transaction types
- add migration for investments_transactions
- validate required fields, numeric rules, and conditional price presence
- add model specs for associations, enums, and validations
- update lightweight code overview documentation

## Impacts

- architecture: connects portfolio and asset models through a dedicated investments transaction entity
- database: adds investments_transactions with foreign keys and date index
- security: low-risk model-layer change, no new controller or user input surface yet
- performance: low impact, indexed date and relation references for future history queries
- tests: model coverage added for core rules and conditional validation behavior
- ui: no visual UI introduced in this issue

## Evidence

- test results:
  - bundle exec rspec spec/models/investments/transaction_spec.rb
  - 12 examples, 0 failures

## Checklist

- [x] Tests passed
- [x] References checked
- [x] Security review completed
- [x] No critical warnings remain