### PR TITLE
Add investments income structure

### DIFF
--- a/app/models/investments/asset.rb
+++ b/app/models/investments/asset.rb
@@ -3,6 +3,7 @@ module Investments
     # Assets are modeled as a global market catalog, not as user-owned records.
     self.table_name = "investments_assets"
 
+    has_many :incomes, class_name: "Investments::Income", dependent: :restrict_with_exception
     has_many :transactions, class_name: "Investments::Transaction", dependent: :restrict_with_exception
 
     enum :category, {

--- a/app/models/investments/income.rb
+++ b/app/models/investments/income.rb
@@ -1,0 +1,31 @@
+module Investments
+  class Income < ApplicationRecord
+    self.table_name = "investments_incomes"
+
+    belongs_to :portfolio, class_name: "Investments::Portfolio"
+    belongs_to :asset, class_name: "Investments::Asset"
+
+    enum :income_type, {
+      dividends: 0,
+      jcp: 1,
+      stock_lending: 2,
+      fii_income: 3,
+      amortization: 4,
+      staking: 5
+    }, prefix: true
+
+    validates :income_type, :gross_amount, :net_amount, :payment_date, presence: true
+    validates :gross_amount, :net_amount, :tax_amount,
+              numericality: { greater_than_or_equal_to: 0 }
+    validate :net_amount_cannot_exceed_gross_amount
+
+    private
+
+    def net_amount_cannot_exceed_gross_amount
+      return if gross_amount.blank? || net_amount.blank?
+      return if net_amount <= gross_amount
+
+      errors.add(:net_amount, "cannot be greater than gross amount")
+    end
+  end
+end

--- a/app/models/investments/portfolio.rb
+++ b/app/models/investments/portfolio.rb
@@ -4,6 +4,7 @@ module Investments
     self.table_name = "investments_portfolios"
 
     belongs_to :user
+    has_many :incomes, class_name: "Investments::Income", dependent: :destroy
     has_many :transactions, class_name: "Investments::Transaction", dependent: :destroy
 
     validates :name, presence: true, uniqueness: { scope: :user_id }

--- a/db/migrate/20260525163318_create_investments_incomes.rb
+++ b/db/migrate/20260525163318_create_investments_incomes.rb
@@ -1,0 +1,19 @@
+class CreateInvestmentsIncomes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :investments_incomes do |t|
+      t.references :portfolio, null: false, foreign_key: { to_table: :investments_portfolios }
+      t.references :asset, null: false, foreign_key: { to_table: :investments_assets }
+      t.integer :income_type, null: false
+      t.decimal :gross_amount, null: false, precision: 15, scale: 4
+      t.decimal :net_amount, null: false, precision: 15, scale: 4
+      t.decimal :tax_amount, null: false, default: 0, precision: 15, scale: 4
+      t.date :payment_date, null: false
+      t.date :reference_date
+      t.text :notes
+
+      t.timestamps
+    end
+
+    add_index :investments_incomes, :payment_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_24_223202) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_25_163318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,23 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_24_223202) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["symbol"], name: "index_investments_assets_on_symbol", unique: true
+  end
+
+  create_table "investments_incomes", force: :cascade do |t|
+    t.bigint "portfolio_id", null: false
+    t.bigint "asset_id", null: false
+    t.integer "income_type", null: false
+    t.decimal "gross_amount", precision: 15, scale: 4, null: false
+    t.decimal "net_amount", precision: 15, scale: 4, null: false
+    t.decimal "tax_amount", precision: 15, scale: 4, default: "0.0", null: false
+    t.date "payment_date", null: false
+    t.date "reference_date"
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["asset_id"], name: "index_investments_incomes_on_asset_id"
+    t.index ["payment_date"], name: "index_investments_incomes_on_payment_date"
+    t.index ["portfolio_id"], name: "index_investments_incomes_on_portfolio_id"
   end
 
   create_table "investments_portfolios", force: :cascade do |t|
@@ -105,6 +122,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_24_223202) do
 
   add_foreign_key "accounts", "users"
   add_foreign_key "categories", "users"
+  add_foreign_key "investments_incomes", "investments_assets", column: "asset_id"
+  add_foreign_key "investments_incomes", "investments_portfolios", column: "portfolio_id"
   add_foreign_key "investments_portfolios", "users"
   add_foreign_key "investments_transactions", "investments_assets", column: "asset_id"
   add_foreign_key "investments_transactions", "investments_portfolios", column: "portfolio_id"

--- a/docs/code-overview.md
+++ b/docs/code-overview.md
@@ -18,6 +18,8 @@ Its goal is to help contributors understand where the main responsibilities live
   global catalog of market assets used as a base for future investment features
 - `app/models/investments/transaction.rb`
   operation history connecting user portfolios to global investment assets
+- `app/models/investments/income.rb`
+  income history linked to a portfolio context and the asset that generated the payment
 
 ## Authentication And User Scope
 

--- a/docs/governance/issue-37-implementation-plan.md
+++ b/docs/governance/issue-37-implementation-plan.md
@@ -1,0 +1,77 @@
+# Issue 37 Implementation Plan
+
+## Objective
+
+Implement the base `Investments::Income` model to track investment income events associated with user portfolios and global assets.
+
+Supported income types:
+
+- dividends
+- JCP
+- stock lending
+- FII income
+- amortization
+- staking
+
+## Affected Files
+
+- `app/models/investments/income.rb`
+- `app/models/investments/portfolio.rb`
+- `app/models/investments/asset.rb`
+- `db/migrate/*_create_investments_incomes.rb`
+- `db/schema.rb`
+- `spec/models/investments/income_spec.rb`
+- `docs/code-overview.md`
+
+## Risks
+
+- Choosing an enum surface that may collide with framework methods
+- Missing ownership clarity where the asset is global but the income belongs to a portfolio
+- Forgetting financial consistency between gross, net, and tax amounts
+
+## Technical Strategy
+
+Implement `Investments::Income` as a namespaced model linked to:
+
+- `Investments::Portfolio` as the user-owned receiving context
+- `Investments::Asset` as the global asset reference
+
+Use an enum for `income_type`, with a safe method prefix.
+
+Add only the approved baseline validations in this issue, deferring stricter business rules to future work.
+
+## Database Impact
+
+Adds a new `investments_incomes` table with:
+
+- `portfolio_id`
+- `asset_id`
+- `income_type`
+- `gross_amount`
+- `net_amount`
+- `tax_amount`
+- `payment_date`
+- `reference_date`
+- `notes`
+- timestamps
+
+Expected constraints:
+
+- foreign keys to portfolios and assets
+- non-null required fields
+- non-null `tax_amount` with default `0`
+- indexes for portfolio, asset, and payment date lookup
+
+## Required Tests
+
+- model specs for associations
+- enum behavior coverage
+- presence validations
+- numeric validations
+- financial consistency between gross and net amounts
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-05-25

--- a/spec/models/investments/income_spec.rb
+++ b/spec/models/investments/income_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+RSpec.describe Investments::Income, type: :model do
+  let(:user) do
+    User.create!(
+      name: "Income Investor",
+      email: "income-investor@example.com",
+      password: "password123"
+    )
+  end
+
+  let(:portfolio) do
+    Investments::Portfolio.create!(
+      user: user,
+      name: "Income Portfolio"
+    )
+  end
+
+  let(:asset) do
+    Investments::Asset.create!(
+      name: "Itausa",
+      symbol: "ITSA4",
+      category: :stock,
+      currency: "BRL"
+    )
+  end
+
+  subject(:income) do
+    described_class.new(
+      portfolio: portfolio,
+      asset: asset,
+      income_type: :dividends,
+      gross_amount: 100.0,
+      net_amount: 85.0,
+      tax_amount: 15.0,
+      payment_date: Date.current,
+      reference_date: Date.current - 5.days,
+      notes: "Quarterly distribution"
+    )
+  end
+
+  it "is valid with required attributes" do
+    expect(income).to be_valid
+  end
+
+  it "belongs to a portfolio" do
+    income.portfolio = nil
+
+    expect(income).not_to be_valid
+    expect(income.errors[:portfolio]).to include("must exist")
+  end
+
+  it "belongs to an asset" do
+    income.asset = nil
+
+    expect(income).not_to be_valid
+    expect(income.errors[:asset]).to include("must exist")
+  end
+
+  it "is invalid without an income type" do
+    income.income_type = nil
+
+    expect(income).not_to be_valid
+    expect(income.errors[:income_type]).to include("can't be blank")
+  end
+
+  it "is invalid without gross amount" do
+    income.gross_amount = nil
+
+    expect(income).not_to be_valid
+    expect(income.errors[:gross_amount]).to include("can't be blank")
+  end
+
+  it "is invalid without net amount" do
+    income.net_amount = nil
+
+    expect(income).not_to be_valid
+    expect(income.errors[:net_amount]).to include("can't be blank")
+  end
+
+  it "is invalid when gross amount is negative" do
+    income.gross_amount = -1
+
+    expect(income).not_to be_valid
+    expect(income.errors[:gross_amount]).to include("must be greater than or equal to 0")
+  end
+
+  it "is invalid when net amount is negative" do
+    income.net_amount = -1
+
+    expect(income).not_to be_valid
+    expect(income.errors[:net_amount]).to include("must be greater than or equal to 0")
+  end
+
+  it "is invalid when tax amount is negative" do
+    income.tax_amount = -1
+
+    expect(income).not_to be_valid
+    expect(income.errors[:tax_amount]).to include("must be greater than or equal to 0")
+  end
+
+  it "is invalid without payment date" do
+    income.payment_date = nil
+
+    expect(income).not_to be_valid
+    expect(income.errors[:payment_date]).to include("can't be blank")
+  end
+
+  it "is invalid when net amount is greater than gross amount" do
+    income.net_amount = 120.0
+
+    expect(income).not_to be_valid
+    expect(income.errors[:net_amount]).to include("cannot be greater than gross amount")
+  end
+
+  it "defines the expected income types" do
+    expect(described_class.income_types.keys).to contain_exactly(
+      "dividends",
+      "jcp",
+      "stock_lending",
+      "fii_income",
+      "amortization",
+      "staking"
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Implements the base Investments::Income model to track investment income events associated with user portfolios and global assets.

## Motivation

Issue #37 requires the first income structure for the investments domain so portfolios can track events such as dividends, JCP, stock lending, FII income, amortization, and staking.

## Main Changes

- add Investments::Income model
- link incomes to Investments::Portfolio and Investments::Asset
- define enum income types
- add migration for investments_incomes
- validate required fields, numeric rules, and gross/net consistency
- add model specs for associations, enums, and validations
- update lightweight code overview documentation

## Impacts

- architecture: expands the investments domain with a dedicated income entity
- database: adds investments_incomes with foreign keys and payment date index
- security: low-risk model-layer change, no new controller or user input surface yet
- performance: low impact, indexed payment date and relation references for future income queries
- tests: model coverage added for core rules and financial consistency validation
- ui: no visual UI introduced in this issue

## Evidence

- test results:
  - bundle exec rspec spec/models/investments/income_spec.rb
  - 12 examples, 0 failures

## Checklist

- [x] Tests passed
- [x] References checked
- [x] Security review completed
- [x] No critical warnings remain