### PR TITLE
Implement average price calculator

### DIFF
--- a/app/services/investments/average_price_calculator.rb
+++ b/app/services/investments/average_price_calculator.rb
@@ -1,0 +1,72 @@
+module Investments
+  # Calculates the current position cost basis for one asset inside one portfolio.
+  #
+  # Business rules:
+  # - buy operations increase quantity and total cost, including fees in the cost basis
+  # - sell operations do not change the average price; they reduce cost proportionally
+  # - selling the full position resets total cost and average price to zero
+  # - selling more than the current position is treated as invalid historical data
+  class AveragePriceCalculator
+    Result = Struct.new(:quantity, :total_cost, :average_price, keyword_init: true)
+
+    ZERO = BigDecimal("0")
+
+    def initialize(portfolio:, asset:)
+      @portfolio = portfolio
+      @asset = asset
+    end
+
+    def self.call(portfolio:, asset:)
+      new(portfolio: portfolio, asset: asset).call
+    end
+
+    def call
+      quantity = ZERO
+      total_cost = ZERO
+
+      transactions.each do |transaction|
+        case transaction.transaction_type
+        when "buy"
+          quantity += transaction.quantity
+          total_cost += transaction_total(transaction)
+        when "sell"
+          raise ArgumentError, "sell quantity exceeds current position" if transaction.quantity > quantity
+
+          average_price = average_price_for(quantity, total_cost)
+          quantity -= transaction.quantity
+          total_cost -= average_price * transaction.quantity
+          total_cost = ZERO if quantity.zero?
+        end
+      end
+
+      Result.new(
+        quantity: quantity,
+        total_cost: total_cost,
+        average_price: average_price_for(quantity, total_cost)
+      )
+    end
+
+    private
+
+    attr_reader :portfolio, :asset
+
+    def transactions
+      # Chronological order is part of the calculation because each sell depends
+      # on the position built by previous buy operations.
+      Investments::Transaction
+        .where(portfolio: portfolio, asset: asset)
+        .where(transaction_type: [:buy, :sell])
+        .order(:date, :id)
+    end
+
+    def transaction_total(transaction)
+      (transaction.quantity * transaction.price) + transaction.fees
+    end
+
+    def average_price_for(quantity, total_cost)
+      return ZERO if quantity.zero?
+
+      total_cost / quantity
+    end
+  end
+end

--- a/docs/governance/issue-38-implementation-plan.md
+++ b/docs/governance/issue-38-implementation-plan.md
@@ -1,0 +1,60 @@
+# Issue 38 Implementation Plan
+
+## Objective
+
+Implement a service object to calculate average price for one asset inside one investment portfolio, based on transaction history.
+
+## Affected Files
+
+- `app/services/investments/average_price_calculator.rb`
+- `spec/services/investments/average_price_calculator_spec.rb`
+
+## Risks
+
+- Misinterpreting how sell operations should affect average price
+- Mixing transactions from other portfolios or assets in the calculation
+- Failing to handle invalid historical data, such as selling more than the current position
+
+## Technical Strategy
+
+Implement `Investments::AveragePriceCalculator` as a service object that receives:
+
+- `portfolio`
+- `asset`
+
+The service should:
+
+- consider only buy and sell transactions
+- process transactions in chronological order
+- calculate weighted average price for buys, including fees
+- reduce quantity and total cost proportionally on sells
+- reset average price when the position becomes zero
+- raise an error if a sell exceeds the current position
+
+The service should return a result object with:
+
+- `quantity`
+- `total_cost`
+- `average_price`
+
+## Database Impact
+
+No database changes are required for this issue.
+
+The calculation is derived from existing `investments_transactions` data.
+
+## Required Tests
+
+- empty history returns zero values
+- class-level call interface works
+- weighted average calculation for buys
+- partial sell keeps average price and reduces cost proportionally
+- full sell resets position and average price
+- transactions from other portfolios or assets are ignored
+- invalid sell history raises an error
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-05-26

--- a/spec/services/investments/average_price_calculator_spec.rb
+++ b/spec/services/investments/average_price_calculator_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe Investments::AveragePriceCalculator do
+  # These examples describe the cost-basis rules used to calculate an investor's
+  # current position for one asset inside one portfolio.
+  let(:user) do
+    User.create!(
+      name: "Investor",
+      email: "average-price-investor@example.com",
+      password: "password123"
+    )
+  end
+
+  let(:portfolio) do
+    Investments::Portfolio.create!(
+      user: user,
+      name: "Main Portfolio"
+    )
+  end
+
+  let(:asset) do
+    Investments::Asset.create!(
+      name: "Apple Inc.",
+      symbol: "AAPL",
+      category: :international,
+      currency: "USD"
+    )
+  end
+
+  subject(:result) { described_class.new(portfolio: portfolio, asset: asset).call }
+
+  it "returns zero values when there are no buy or sell transactions" do
+    expect(result.quantity).to eq(BigDecimal("0"))
+    expect(result.total_cost).to eq(BigDecimal("0"))
+    expect(result.average_price).to eq(BigDecimal("0"))
+  end
+
+  it "can be called through the class-level service interface" do
+    create_transaction(:buy, quantity: 1, price: 15)
+
+    result = described_class.call(portfolio: portfolio, asset: asset)
+
+    expect(result.average_price).to eq(BigDecimal("15"))
+  end
+
+  it "calculates weighted average price for buy transactions including fees" do
+    create_transaction(:buy, quantity: 10, price: 20, fees: 5, date: Date.new(2026, 1, 1))
+    create_transaction(:buy, quantity: 5, price: 30, fees: 10, date: Date.new(2026, 1, 2))
+
+    expect(result.quantity).to eq(BigDecimal("15"))
+    expect(result.total_cost).to eq(BigDecimal("365"))
+    expect(result.average_price).to eq(BigDecimal("365") / BigDecimal("15"))
+  end
+
+  it "keeps the average price after a partial sell and reduces total cost proportionally" do
+    create_transaction(:buy, quantity: 10, price: 20, date: Date.new(2026, 1, 1))
+    create_transaction(:buy, quantity: 10, price: 40, date: Date.new(2026, 1, 2))
+    create_transaction(:sell, quantity: 5, price: 50, date: Date.new(2026, 1, 3))
+
+    expect(result.quantity).to eq(BigDecimal("15"))
+    expect(result.total_cost).to eq(BigDecimal("450"))
+    expect(result.average_price).to eq(BigDecimal("30"))
+  end
+
+  it "resets total cost and average price after selling the full position" do
+    create_transaction(:buy, quantity: 3, price: 100, date: Date.new(2026, 1, 1))
+    create_transaction(:sell, quantity: 3, price: 120, date: Date.new(2026, 1, 2))
+
+    expect(result.quantity).to eq(BigDecimal("0"))
+    expect(result.total_cost).to eq(BigDecimal("0"))
+    expect(result.average_price).to eq(BigDecimal("0"))
+  end
+
+  it "ignores transactions from other portfolios and assets" do
+    other_portfolio = Investments::Portfolio.create!(user: user, name: "Other Portfolio")
+    other_asset = Investments::Asset.create!(
+      name: "Microsoft",
+      symbol: "MSFT",
+      category: :international,
+      currency: "USD"
+    )
+
+    create_transaction(:buy, quantity: 2, price: 10)
+    create_transaction(:buy, quantity: 100, price: 1, portfolio: other_portfolio)
+    create_transaction(:buy, quantity: 100, price: 1, asset: other_asset)
+
+    expect(result.quantity).to eq(BigDecimal("2"))
+    expect(result.total_cost).to eq(BigDecimal("20"))
+    expect(result.average_price).to eq(BigDecimal("10"))
+  end
+
+  it "raises an error when a sell exceeds the current position" do
+    create_transaction(:buy, quantity: 1, price: 10, date: Date.new(2026, 1, 1))
+    create_transaction(:sell, quantity: 2, price: 10, date: Date.new(2026, 1, 2))
+
+    expect { result }.to raise_error(ArgumentError, "sell quantity exceeds current position")
+  end
+
+  def create_transaction(
+    transaction_type,
+    quantity:,
+    price:,
+    fees: 0,
+    date: Date.new(2026, 1, 1),
+    portfolio: self.portfolio,
+    asset: self.asset
+  )
+    Investments::Transaction.create!(
+      portfolio: portfolio,
+      asset: asset,
+      transaction_type: transaction_type,
+      quantity: quantity,
+      price: price,
+      fees: fees,
+      date: date
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Implements a service object to calculate average price and current position cost basis for one asset inside one investment portfolio.

## Motivation

Issue #38 requires the average price calculation logic for investment positions, with correct handling for buy and sell operations.

## Main Changes

- add Investments::AveragePriceCalculator service object
- calculate weighted average price based on buy operations
- include fees in purchase cost basis
- handle sell operations by reducing quantity and cost proportionally while preserving average price of the remaining position
- reset position cost and average price when quantity becomes zero
- raise an error for invalid sell history that exceeds current position
- add service specs covering calculation scenarios
- add governance implementation plan for the issue

## Impacts

- architecture: introduces a dedicated service object for calculation logic as requested by the issue
- database: no database changes
- security: low-risk pure domain logic, no user input surface added
- performance: scoped query by portfolio and asset, ordered chronologically for deterministic calculation
- tests: service coverage added for empty history, weighted average, partial sell, full sell, invalid sells, and scoping
- ui: no visual UI introduced in this issue

## Evidence

- test results:
  - bundle exec rspec spec/services/investments/average_price_calculator_spec.rb
  - 7 examples, 0 failures

## Checklist

- [x] Tests passed
- [x] References checked
- [x] Security review completed
- [x] No critical warnings remain