### PR TITLE
Add current position calculator

### DIFF
--- a/app/services/investments/current_position_calculator.rb
+++ b/app/services/investments/current_position_calculator.rb
@@ -1,0 +1,44 @@
+module Investments
+  class CurrentPositionCalculator
+    Result = Struct.new(:quantity, keyword_init: true)
+
+    ZERO = BigDecimal("0")
+
+    def initialize(portfolio:, asset:)
+      @portfolio = portfolio
+      @asset = asset
+    end
+
+    def self.call(portfolio:, asset:)
+      new(portfolio: portfolio, asset: asset).call
+    end
+
+    def call
+      quantity = ZERO
+
+      transactions.each do |transaction|
+        case transaction.transaction_type
+        when "buy"
+          quantity += transaction.quantity
+        when "sell"
+          raise ArgumentError, "sell quantity exceeds current position" if transaction.quantity > quantity
+
+          quantity -= transaction.quantity
+        end
+      end
+
+      Result.new(quantity: quantity)
+    end
+
+    private
+
+    attr_reader :portfolio, :asset
+
+    def transactions
+      Investments::Transaction
+        .where(portfolio: portfolio, asset: asset)
+        .where(transaction_type: [:buy, :sell])
+        .order(:date, :id)
+    end
+  end
+end

--- a/docs/governance/issue-39-implementation-plan.md
+++ b/docs/governance/issue-39-implementation-plan.md
@@ -1,0 +1,59 @@
+# Issue 39 Implementation Plan
+
+## Objective
+
+Implement a service object to calculate the current quantity held for one asset inside one investment portfolio from transaction history.
+
+## Affected Files
+
+- `app/services/investments/current_position_calculator.rb`
+- `spec/services/investments/current_position_calculator_spec.rb`
+
+## Risks
+
+- Misinterpreting how sell operations should reduce the current position
+- Mixing transactions from other portfolios or assets in the calculation
+- Failing to detect invalid history where sell quantity exceeds the current position
+
+## Technical Strategy
+
+Implement `Investments::CurrentPositionCalculator` as a service object that receives:
+
+- `portfolio`
+- `asset`
+
+The service should:
+
+- consider buy and sell transactions
+- process transactions in chronological order
+- increase quantity on buys
+- reduce quantity on sells
+- raise an error if a sell exceeds the current position
+- ignore transactions from other portfolios or assets
+- ignore other transaction types for now
+
+The service should return a small result object with:
+
+- `quantity`
+
+## Database Impact
+
+No database changes are required for this issue.
+
+The calculation is derived from existing `investments_transactions` data.
+
+## Required Tests
+
+- empty history returns zero quantity
+- class-level call interface works
+- multiple buys accumulate quantity
+- partial sell reduces quantity
+- full sell resets quantity to zero
+- transactions from other portfolios or assets are ignored
+- invalid sell history raises an error
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-05-26

--- a/spec/services/investments/current_position_calculator_spec.rb
+++ b/spec/services/investments/current_position_calculator_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe Investments::CurrentPositionCalculator do
+  let(:user) do
+    User.create!(
+      name: "Position Investor",
+      email: "position-investor@example.com",
+      password: "password123"
+    )
+  end
+
+  let(:portfolio) do
+    Investments::Portfolio.create!(
+      user: user,
+      name: "Main Portfolio"
+    )
+  end
+
+  let(:asset) do
+    Investments::Asset.create!(
+      name: "Apple Inc.",
+      symbol: "AAPL",
+      category: :international,
+      currency: "USD"
+    )
+  end
+
+  subject(:result) { described_class.new(portfolio: portfolio, asset: asset).call }
+
+  it "returns zero quantity when there are no buy or sell transactions" do
+    expect(result.quantity).to eq(BigDecimal("0"))
+  end
+
+  it "can be called through the class-level service interface" do
+    create_transaction(:buy, quantity: 3, price: 10)
+
+    result = described_class.call(portfolio: portfolio, asset: asset)
+
+    expect(result.quantity).to eq(BigDecimal("3"))
+  end
+
+  it "accumulates quantity across multiple buy transactions" do
+    create_transaction(:buy, quantity: 10, price: 20, date: Date.new(2026, 1, 1))
+    create_transaction(:buy, quantity: 5, price: 30, date: Date.new(2026, 1, 2))
+
+    expect(result.quantity).to eq(BigDecimal("15"))
+  end
+
+  it "reduces quantity after a partial sell" do
+    create_transaction(:buy, quantity: 10, price: 20, date: Date.new(2026, 1, 1))
+    create_transaction(:buy, quantity: 10, price: 40, date: Date.new(2026, 1, 2))
+    create_transaction(:sell, quantity: 5, price: 50, date: Date.new(2026, 1, 3))
+
+    expect(result.quantity).to eq(BigDecimal("15"))
+  end
+
+  it "resets quantity to zero after selling the full position" do
+    create_transaction(:buy, quantity: 3, price: 100, date: Date.new(2026, 1, 1))
+    create_transaction(:sell, quantity: 3, price: 120, date: Date.new(2026, 1, 2))
+
+    expect(result.quantity).to eq(BigDecimal("0"))
+  end
+
+  it "ignores transactions from other portfolios and assets" do
+    other_portfolio = Investments::Portfolio.create!(user: user, name: "Other Portfolio")
+    other_asset = Investments::Asset.create!(
+      name: "Microsoft",
+      symbol: "MSFT",
+      category: :international,
+      currency: "USD"
+    )
+
+    create_transaction(:buy, quantity: 2, price: 10)
+    create_transaction(:buy, quantity: 100, price: 1, portfolio: other_portfolio)
+    create_transaction(:buy, quantity: 100, price: 1, asset: other_asset)
+
+    expect(result.quantity).to eq(BigDecimal("2"))
+  end
+
+  it "raises an error when a sell exceeds the current position" do
+    create_transaction(:buy, quantity: 1, price: 10, date: Date.new(2026, 1, 1))
+    create_transaction(:sell, quantity: 2, price: 10, date: Date.new(2026, 1, 2))
+
+    expect { result }.to raise_error(ArgumentError, "sell quantity exceeds current position")
+  end
+
+  def create_transaction(
+    transaction_type,
+    quantity:,
+    price:,
+    fees: 0,
+    date: Date.new(2026, 1, 1),
+    portfolio: self.portfolio,
+    asset: self.asset
+  )
+    Investments::Transaction.create!(
+      portfolio: portfolio,
+      asset: asset,
+      transaction_type: transaction_type,
+      quantity: quantity,
+      price: price,
+      fees: fees,
+      date: date
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Implements a service object to calculate the current quantity held for one asset inside one investment portfolio from transaction history.

## Motivation

Issue #39 requires the current position calculation logic so buy and sell events can be reflected correctly in the held quantity.

## Main Changes

- add Investments::CurrentPositionCalculator service object
- calculate current quantity from buy and sell transactions
- process transactions in chronological order
- ignore transactions from other portfolios and assets
- raise an error for invalid sell history that exceeds the current position
- add service specs covering accumulation, sell handling, reset to zero, scoping, and invalid history
- add governance implementation plan for the issue

## Impacts

- architecture: introduces a dedicated service object for current position calculation
- database: no database changes
- security: low-risk pure domain logic, no user input surface added
- performance: scoped query by portfolio and asset, ordered chronologically for deterministic calculation
- tests: service coverage added for the core calculation scenarios and edge cases
- ui: no visual UI introduced in this issue

## Evidence

- test results:
  - bundle exec rspec spec/services/investments/current_position_calculator_spec.rb
  - 7 examples, 0 failures

## Checklist

- [x] Tests passed
- [x] References checked
- [x] Security review completed
- [x] No critical warnings remain