### PR TITLE
Add investment portfolio dashboard

### DIFF
--- a/app/controllers/investments/portfolios_controller.rb
+++ b/app/controllers/investments/portfolios_controller.rb
@@ -7,6 +7,7 @@ module Investments
     end
 
     def show
+      @dashboard = Investments::PortfolioDashboardBuilder.call(portfolio: @portfolio)
     end
 
     def new

--- a/app/services/investments/portfolio_dashboard_builder.rb
+++ b/app/services/investments/portfolio_dashboard_builder.rb
@@ -1,0 +1,118 @@
+module Investments
+  class PortfolioDashboardBuilder
+    AssetEntry = Struct.new(
+      :asset,
+      :quantity,
+      :average_price,
+      :invested_amount,
+      :current_value,
+      :allocation_percentage,
+      keyword_init: true
+    )
+
+    Result = Struct.new(
+      :portfolio,
+      :total_invested_amount,
+      :current_portfolio_value,
+      :unrealized_profit_loss,
+      :passive_income_summary,
+      :asset_entries,
+      keyword_init: true
+    )
+
+    ZERO = BigDecimal("0")
+
+    def initialize(portfolio:)
+      @portfolio = portfolio
+    end
+
+    def self.call(portfolio:)
+      new(portfolio: portfolio).call
+    end
+
+    def call
+      grouped_transactions = transactions.group_by(&:asset)
+      base_entries = grouped_transactions.filter_map do |asset, asset_transactions|
+        build_asset_entry(asset, asset_transactions)
+      end
+
+      total_invested_amount = base_entries.sum { |entry| entry.invested_amount }
+      asset_entries = attach_allocation(base_entries, total_invested_amount)
+
+      Result.new(
+        portfolio: portfolio,
+        total_invested_amount: total_invested_amount,
+        current_portfolio_value: total_invested_amount,
+        unrealized_profit_loss: ZERO,
+        passive_income_summary: incomes.sum(&:net_amount),
+        asset_entries: asset_entries.sort_by { |entry| [-entry.invested_amount, entry.asset.symbol] }
+      )
+    end
+
+    private
+
+    attr_reader :portfolio
+
+    def transactions
+      portfolio
+        .transactions
+        .includes(:asset)
+        .where(transaction_type: [:buy, :sell])
+        .order(:date, :id)
+    end
+
+    def incomes
+      @incomes ||= portfolio.incomes.to_a
+    end
+
+    def build_asset_entry(asset, asset_transactions)
+      quantity = ZERO
+      total_cost = ZERO
+
+      asset_transactions.each do |transaction|
+        case transaction.transaction_type
+        when "buy"
+          quantity += transaction.quantity
+          total_cost += (transaction.quantity * transaction.price) + transaction.fees
+        when "sell"
+          raise ArgumentError, "sell quantity exceeds current position" if transaction.quantity > quantity
+
+          average_price = average_price_for(quantity, total_cost)
+          quantity -= transaction.quantity
+          total_cost -= average_price * transaction.quantity
+          total_cost = ZERO if quantity.zero?
+        end
+      end
+
+      return if quantity.zero?
+
+      AssetEntry.new(
+        asset: asset,
+        quantity: quantity,
+        average_price: average_price_for(quantity, total_cost),
+        invested_amount: total_cost,
+        current_value: total_cost,
+        allocation_percentage: ZERO
+      )
+    end
+
+    def attach_allocation(entries, total_invested_amount)
+      entries.map do |entry|
+        entry.allocation_percentage =
+          if total_invested_amount.zero?
+            ZERO
+          else
+            (entry.invested_amount / total_invested_amount) * 100
+          end
+
+        entry
+      end
+    end
+
+    def average_price_for(quantity, total_cost)
+      return ZERO if quantity.zero?
+
+      total_cost / quantity
+    end
+  end
+end

--- a/app/views/investments/portfolios/show.html.erb
+++ b/app/views/investments/portfolios/show.html.erb
@@ -1,21 +1,134 @@
-<div class="container mt-4">
-  <%= link_to investments_portfolios_path, class: "bg-black text-white text-decoration-none p-2" do %>
-    <i class="fa-solid fa-circle-left"></i>volta
+<div class="container mt-8 max-w-7xl">
+  <%= link_to investments_portfolios_path, class: "inline-flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2 text-sm text-white text-decoration-none transition hover:bg-gray-700" do %>
+    <i class="fa-solid fa-circle-left"></i>Voltar
   <% end %>
 
-  <div class="mt-4 rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
-    <h1 class="text-2xl font-bold text-gray-900"><%= @portfolio.name %></h1>
-    <p class="mt-2 text-gray-600">Responsavel: <%= @portfolio.user.name %></p>
-    <p class="text-gray-600">Criado em: <%= l(@portfolio.created_at.to_date) %></p>
+  <div class="mt-6 overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-sm">
+    <div class="border-b border-gray-100 bg-gradient-to-r from-slate-50 to-white px-6 py-6 lg:px-8 lg:py-7">
+      <div class="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Portfolio Dashboard</p>
+          <h1 class="mt-2 text-3xl font-semibold text-gray-900"><%= @portfolio.name %></h1>
+          <div class="mt-3 space-y-1">
+            <p class="text-sm text-gray-600">Responsavel: <%= @portfolio.user.name %></p>
+            <p class="text-sm text-gray-500">Criado em <%= l(@portfolio.created_at.to_date) %></p>
+          </div>
+        </div>
 
-    <div class="mt-4 flex gap-3">
-      <%= link_to edit_investments_portfolio_path(@portfolio) do %>
-        <%= render ButtonComponent.new(label: "Edit") %>
-      <% end %>
+        <div class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3.5 text-sm leading-6 text-amber-800 lg:max-w-md">
+          Valor atual e lucro/prejuizo usam custo medio como aproximacao ate a integracao com cotacoes de mercado.
+        </div>
+      </div>
+    </div>
 
-      <%= link_to investments_portfolio_path(@portfolio), data: { turbo_method: :delete, turbo_confirm: "Tem certeza que deseja apagar este portfolio?" } do %>
-        <%= render ButtonComponent.new(label: "Apagar") %>
-      <% end %>
+    <div class="px-6 py-6 lg:px-8 lg:py-8">
+      <div class="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+        <div class="rounded-2xl border border-gray-200 bg-slate-50 p-5">
+          <p class="text-sm text-gray-500">Total investido</p>
+          <p class="mt-3 text-2xl font-semibold text-gray-900"><%= number_to_currency(@dashboard.total_invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %></p>
+        </div>
+
+        <div class="rounded-2xl border border-gray-200 bg-slate-50 p-5">
+          <p class="text-sm text-gray-500">Valor atual da carteira</p>
+          <p class="mt-3 text-2xl font-semibold text-gray-900"><%= number_to_currency(@dashboard.current_portfolio_value, unit: "R$ ", separator: ",", delimiter: ".") %></p>
+        </div>
+
+        <div class="rounded-2xl border border-gray-200 bg-slate-50 p-5">
+          <p class="text-sm text-gray-500">Lucro/Prejuizo nao realizado</p>
+          <p class="mt-3 text-2xl font-semibold text-gray-900"><%= number_to_currency(@dashboard.unrealized_profit_loss, unit: "R$ ", separator: ",", delimiter: ".") %></p>
+        </div>
+
+        <div class="rounded-2xl border border-gray-200 bg-slate-50 p-5">
+          <p class="text-sm text-gray-500">Renda passiva liquida</p>
+          <p class="mt-3 text-2xl font-semibold text-gray-900"><%= number_to_currency(@dashboard.passive_income_summary, unit: "R$ ", separator: ",", delimiter: ".") %></p>
+        </div>
+      </div>
+
+      <div class="mt-10 grid gap-6 xl:grid-cols-[1.35fr_0.65fr]">
+        <div class="rounded-2xl border border-gray-200 bg-white p-5 lg:p-6">
+          <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-gray-900">Posicoes por ativo</h2>
+            <span class="text-sm text-gray-500"><%= @dashboard.asset_entries.count %> ativos</span>
+          </div>
+
+          <% if @dashboard.asset_entries.any? %>
+            <div class="mt-5 overflow-x-auto">
+              <table class="min-w-full text-left text-sm">
+                <thead class="border-b border-gray-200 text-gray-500">
+                  <tr>
+                    <th class="py-3.5 pr-6 font-medium">Ativo</th>
+                    <th class="py-3.5 pr-6 font-medium">Quantidade</th>
+                    <th class="py-3.5 pr-6 font-medium">Preco medio</th>
+                    <th class="py-3.5 pr-6 font-medium">Investido</th>
+                    <th class="py-3.5 font-medium">Alocacao</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @dashboard.asset_entries.each do |entry| %>
+                    <tr class="border-b border-gray-100 last:border-b-0">
+                      <td class="py-4 pr-6">
+                        <div class="font-medium text-gray-900"><%= entry.asset.symbol %></div>
+                        <div class="mt-1 text-xs text-gray-500"><%= entry.asset.name %></div>
+                      </td>
+                      <td class="py-4 pr-6 text-gray-700"><%= number_with_precision(entry.quantity, precision: 8, strip_insignificant_zeros: true) %></td>
+                      <td class="py-4 pr-6 text-gray-700"><%= number_to_currency(entry.average_price, unit: "R$ ", separator: ",", delimiter: ".") %></td>
+                      <td class="py-4 pr-6 text-gray-700"><%= number_to_currency(entry.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %></td>
+                      <td class="py-4">
+                        <div class="flex items-center gap-3">
+                          <div class="h-2 w-full max-w-28 overflow-hidden rounded-full bg-gray-100">
+                            <div class="h-full rounded-full bg-blue-600" style="width: <%= [entry.allocation_percentage.to_f.round(2), 100].min %>%"></div>
+                          </div>
+                          <span class="min-w-16 text-gray-700"><%= number_with_precision(entry.allocation_percentage, precision: 2) %>%</span>
+                        </div>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          <% else %>
+            <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-gray-600">
+              Nenhuma posicao de investimento encontrada para este portfolio.
+            </div>
+          <% end %>
+        </div>
+
+        <div class="rounded-2xl border border-gray-200 bg-white p-5 lg:p-6">
+          <h2 class="text-lg font-semibold text-gray-900">Resumo rapido</h2>
+
+          <dl class="mt-5 space-y-5 text-sm">
+            <div class="flex items-start justify-between gap-4">
+              <dt class="text-gray-500">Ativos com posicao</dt>
+              <dd class="font-medium text-gray-900"><%= @dashboard.asset_entries.count %></dd>
+            </div>
+            <div class="flex items-start justify-between gap-4">
+              <dt class="text-gray-500">Maior alocacao</dt>
+              <dd class="font-medium text-gray-900">
+                <% top_asset = @dashboard.asset_entries.first %>
+                <%= top_asset ? "#{top_asset.asset.symbol} (#{number_with_precision(top_asset.allocation_percentage, precision: 2)}%)" : "-" %>
+              </dd>
+            </div>
+            <div class="flex items-start justify-between gap-4">
+              <dt class="text-gray-500">Renda passiva liquida</dt>
+              <dd class="font-medium text-gray-900"><%= number_to_currency(@dashboard.passive_income_summary, unit: "R$ ", separator: ",", delimiter: ".") %></dd>
+            </div>
+            <div class="flex items-start justify-between gap-4">
+              <dt class="text-gray-500">Valor atual</dt>
+              <dd class="font-medium text-gray-900"><%= number_to_currency(@dashboard.current_portfolio_value, unit: "R$ ", separator: ",", delimiter: ".") %></dd>
+            </div>
+          </dl>
+
+          <div class="mt-8 flex flex-wrap gap-3">
+            <%= link_to edit_investments_portfolio_path(@portfolio) do %>
+              <%= render ButtonComponent.new(label: "Edit") %>
+            <% end %>
+
+            <%= link_to investments_portfolio_path(@portfolio), data: { turbo_method: :delete, turbo_confirm: "Tem certeza que deseja apagar este portfolio?" } do %>
+              <%= render ButtonComponent.new(label: "Apagar") %>
+            <% end %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,8 @@
 puts "Limpando dados..."
+Investments::Income.delete_all
+Investments::Transaction.delete_all
+Investments::Asset.delete_all
+Investments::Portfolio.delete_all
 Transaction.delete_all
 Category.delete_all
 Account.delete_all
@@ -16,8 +20,8 @@ puts "Criando categorias globais..."
 global_categories = [
   { name: "Salário", is_income: true, icon: "💰", color: "#00cc66" },
   { name: "Aluguel", is_income: false, icon: "🏠", color: "#ff6666" },
-  { name: "Alimentação", is_income: false, icon: "🍴", color: "#3366ff" },
-  { name: "Água", is_income: true, icon: "🚿", color: "#1F5BC5" },
+  { name: "Alimentação", is_income: false, icon: "🍔", color: "#3366ff" },
+  { name: "Água", is_income: true, icon: "💳", color: "#1F5BC5" },
   { name: "Investimentos", is_income: true, icon: "📈", color: "#ffaa00" }
 ]
 
@@ -87,4 +91,114 @@ Transaction.create!(
   account: account2
 )
 
+puts "Criando portfolio de investimentos..."
+portfolio = Investments::Portfolio.create!(
+  name: "Portfolio Principal",
+  user: user
+)
+
+puts "Criando ativos de investimentos..."
+apple = Investments::Asset.create!(
+  name: "Apple Inc.",
+  symbol: "AAPL",
+  category: :international,
+  currency: "USD"
+)
+
+xpml = Investments::Asset.create!(
+  name: "XP Malls",
+  symbol: "XPML11",
+  category: :fii,
+  currency: "BRL"
+)
+
+btc = Investments::Asset.create!(
+  name: "Bitcoin",
+  symbol: "BTC",
+  category: :crypto,
+  currency: "USD"
+)
+
+puts "Criando transações de investimentos..."
+Investments::Transaction.create!(
+  portfolio: portfolio,
+  asset: apple,
+  transaction_type: :buy,
+  quantity: 10,
+  price: 20,
+  fees: 5,
+  date: Date.today - 25,
+  notes: "Primeira compra"
+)
+
+Investments::Transaction.create!(
+  portfolio: portfolio,
+  asset: apple,
+  transaction_type: :buy,
+  quantity: 5,
+  price: 30,
+  fees: 10,
+  date: Date.today - 18,
+  notes: "Reforço de posição"
+)
+
+Investments::Transaction.create!(
+  portfolio: portfolio,
+  asset: apple,
+  transaction_type: :sell,
+  quantity: 5,
+  price: 42,
+  fees: 0,
+  date: Date.today - 10,
+  notes: "Realização parcial"
+)
+
+Investments::Transaction.create!(
+  portfolio: portfolio,
+  asset: xpml,
+  transaction_type: :buy,
+  quantity: 20,
+  price: 10,
+  fees: 0,
+  date: Date.today - 15,
+  notes: "Entrada em FII"
+)
+
+Investments::Transaction.create!(
+  portfolio: portfolio,
+  asset: btc,
+  transaction_type: :buy,
+  quantity: 0.25,
+  price: 250000,
+  fees: 50,
+  date: Date.today - 12,
+  notes: "Compra inicial de BTC"
+)
+
+puts "Criando rendimentos de investimentos..."
+Investments::Income.create!(
+  portfolio: portfolio,
+  asset: xpml,
+  income_type: :fii_income,
+  gross_amount: 24,
+  net_amount: 24,
+  tax_amount: 0,
+  payment_date: Date.today - 3,
+  reference_date: Date.today - 8,
+  notes: "Rendimento mensal do FII"
+)
+
+Investments::Income.create!(
+  portfolio: portfolio,
+  asset: apple,
+  income_type: :dividends,
+  gross_amount: 18,
+  net_amount: 15.3,
+  tax_amount: 2.7,
+  payment_date: Date.today - 6,
+  reference_date: Date.today - 14,
+  notes: "Dividendos trimestrais"
+)
+
+puts "Dados de investimentos criados para visualizar o dashboard."
 puts "Seeds finalizados com sucesso!"

--- a/docs/governance/issue-40-implementation-plan.md
+++ b/docs/governance/issue-40-implementation-plan.md
@@ -1,0 +1,55 @@
+# Issue 40 Implementation Plan
+
+## Objective
+
+Create the initial investment portfolio dashboard with the metrics currently supported by the investments domain.
+
+## Affected Files
+
+- `app/controllers/investments/portfolios_controller.rb`
+- `app/views/investments/portfolios/show.html.erb`
+- `app/services/investments/portfolio_dashboard_builder.rb`
+- `spec/services/investments/portfolio_dashboard_builder_spec.rb`
+- `spec/requests/investments/portfolios_spec.rb`
+
+## Risks
+
+- Dashboard fields may imply market pricing that does not exist yet
+- Naive per-asset calculations could introduce N+1 queries
+- Aggregating transactions and incomes incorrectly could produce misleading metrics
+
+## Technical Strategy
+
+Use the portfolio show page as the initial dashboard entry point.
+
+Implement a dedicated service object to build dashboard data from:
+
+- portfolio transactions
+- portfolio incomes
+
+Use a single transaction query and a single income query, grouped in memory by asset.
+
+Because there is no current market quote source yet, populate:
+
+- current portfolio value using current cost basis
+- unrealized profit/loss as zero
+
+The UI should make this approximation explicit.
+
+## Database Impact
+
+No database changes are required for this issue.
+
+The dashboard is derived from existing portfolios, transactions, assets, and incomes.
+
+## Required Tests
+
+- service specs for aggregated dashboard metrics
+- request spec to verify dashboard rendering
+- request spec to verify user scoping on portfolio show/dashboard
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-06-02

--- a/spec/requests/investments/portfolios_spec.rb
+++ b/spec/requests/investments/portfolios_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe "Investments::Portfolios", type: :request do
     )
   end
 
+  let!(:asset) do
+    Investments::Asset.create!(
+      name: "Apple Inc.",
+      symbol: "AAPL",
+      category: :international,
+      currency: "USD"
+    )
+  end
+
   before do
     sign_in user
   end
@@ -46,6 +55,53 @@ RSpec.describe "Investments::Portfolios", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Main Portfolio")
       expect(response.body).not_to include(other_portfolio.name)
+    end
+  end
+
+  describe "GET /show" do
+    before do
+      Investments::Transaction.create!(
+        portfolio: portfolio,
+        asset: asset,
+        transaction_type: :buy,
+        quantity: 2,
+        price: 10,
+        fees: 0,
+        date: Date.current
+      )
+
+      Investments::Income.create!(
+        portfolio: portfolio,
+        asset: asset,
+        income_type: :dividends,
+        gross_amount: 5,
+        net_amount: 5,
+        tax_amount: 0,
+        payment_date: Date.current
+      )
+    end
+
+    it "renders the initial dashboard metrics for the portfolio" do
+      get investments_portfolio_path(portfolio)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Portfolio Dashboard")
+      expect(response.body).to include("Total investido")
+      expect(response.body).to include("Renda passiva liquida")
+      expect(response.body).to include("AAPL")
+    end
+
+    it "returns not found for a portfolio from another user" do
+      other_user = User.create!(
+        name: "Another User",
+        email: "another-user@example.com",
+        password: "password123"
+      )
+      other_portfolio = Investments::Portfolio.create!(user: other_user, name: "Private Portfolio")
+
+      get investments_portfolio_path(other_portfolio)
+
+      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/services/investments/portfolio_dashboard_builder_spec.rb
+++ b/spec/services/investments/portfolio_dashboard_builder_spec.rb
@@ -1,0 +1,116 @@
+require "rails_helper"
+
+RSpec.describe Investments::PortfolioDashboardBuilder do
+  let(:user) do
+    User.create!(
+      name: "Dashboard Investor",
+      email: "dashboard-investor@example.com",
+      password: "password123"
+    )
+  end
+
+  let(:portfolio) do
+    Investments::Portfolio.create!(
+      user: user,
+      name: "Main Portfolio"
+    )
+  end
+
+  let(:stock_asset) do
+    Investments::Asset.create!(
+      name: "Apple Inc.",
+      symbol: "AAPL",
+      category: :international,
+      currency: "USD"
+    )
+  end
+
+  let(:fii_asset) do
+    Investments::Asset.create!(
+      name: "XP Malls",
+      symbol: "XPML11",
+      category: :fii,
+      currency: "BRL"
+    )
+  end
+
+  subject(:dashboard) { described_class.call(portfolio: portfolio) }
+
+  it "returns zeroed summary when the portfolio has no positions or incomes" do
+    expect(dashboard.total_invested_amount).to eq(BigDecimal("0"))
+    expect(dashboard.current_portfolio_value).to eq(BigDecimal("0"))
+    expect(dashboard.unrealized_profit_loss).to eq(BigDecimal("0"))
+    expect(dashboard.passive_income_summary).to eq(BigDecimal("0"))
+    expect(dashboard.asset_entries).to be_empty
+  end
+
+  it "builds asset entries and portfolio totals from current positions" do
+    create_transaction(stock_asset, :buy, quantity: 10, price: 20, fees: 5, date: Date.new(2026, 1, 1))
+    create_transaction(stock_asset, :buy, quantity: 5, price: 30, fees: 10, date: Date.new(2026, 1, 2))
+    create_transaction(stock_asset, :sell, quantity: 5, price: 40, fees: 0, date: Date.new(2026, 1, 3))
+    create_transaction(fii_asset, :buy, quantity: 20, price: 10, fees: 0, date: Date.new(2026, 1, 4))
+
+    expected_apple_cost = BigDecimal("365") - ((BigDecimal("365") / BigDecimal("15")) * BigDecimal("5"))
+    expected_total = expected_apple_cost + BigDecimal("200")
+
+    expect(dashboard.total_invested_amount).to eq(expected_total)
+    expect(dashboard.current_portfolio_value).to eq(expected_total)
+    expect(dashboard.unrealized_profit_loss).to eq(BigDecimal("0"))
+    expect(dashboard.asset_entries.map { |entry| entry.asset.symbol }).to eq(%w[AAPL XPML11])
+
+    apple_entry = dashboard.asset_entries.find { |entry| entry.asset == stock_asset }
+    fii_entry = dashboard.asset_entries.find { |entry| entry.asset == fii_asset }
+
+    expect(apple_entry.quantity).to eq(BigDecimal("10"))
+    expect(apple_entry.average_price).to eq(expected_apple_cost / BigDecimal("10"))
+    expect(apple_entry.invested_amount).to eq(expected_apple_cost)
+
+    expect(fii_entry.quantity).to eq(BigDecimal("20"))
+    expect(fii_entry.average_price).to eq(BigDecimal("10"))
+    expect(fii_entry.invested_amount).to eq(BigDecimal("200"))
+  end
+
+  it "calculates passive income summary from net amounts" do
+    create_income(stock_asset, net_amount: 85, gross_amount: 100, tax_amount: 15)
+    create_income(fii_asset, net_amount: 42, gross_amount: 42, tax_amount: 0)
+
+    expect(dashboard.passive_income_summary).to eq(BigDecimal("127"))
+  end
+
+  it "ignores transactions and incomes from other portfolios" do
+    other_portfolio = Investments::Portfolio.create!(user: user, name: "Other Portfolio")
+
+    create_transaction(stock_asset, :buy, quantity: 2, price: 10, portfolio: portfolio)
+    create_transaction(stock_asset, :buy, quantity: 100, price: 1, portfolio: other_portfolio)
+    create_income(stock_asset, net_amount: 5, gross_amount: 5, tax_amount: 0, portfolio: portfolio)
+    create_income(stock_asset, net_amount: 99, gross_amount: 99, tax_amount: 0, portfolio: other_portfolio)
+
+    expect(dashboard.total_invested_amount).to eq(BigDecimal("20"))
+    expect(dashboard.passive_income_summary).to eq(BigDecimal("5"))
+    expect(dashboard.asset_entries.first.quantity).to eq(BigDecimal("2"))
+  end
+
+  def create_transaction(asset, transaction_type, quantity:, price:, fees: 0, date: Date.new(2026, 1, 1), portfolio: self.portfolio)
+    Investments::Transaction.create!(
+      portfolio: portfolio,
+      asset: asset,
+      transaction_type: transaction_type,
+      quantity: quantity,
+      price: price,
+      fees: fees,
+      date: date
+    )
+  end
+
+  def create_income(asset, net_amount:, gross_amount:, tax_amount:, payment_date: Date.current, portfolio: self.portfolio)
+    Investments::Income.create!(
+      portfolio: portfolio,
+      asset: asset,
+      income_type: :dividends,
+      gross_amount: gross_amount,
+      net_amount: net_amount,
+      tax_amount: tax_amount,
+      payment_date: payment_date
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Implements the initial investment portfolio dashboard using the current investments domain data already available in the application.

## Motivation

Issue #40 requires a first dashboard view with portfolio metrics, passive income summary, and asset allocation.

## Main Changes

- add Investments::PortfolioDashboardBuilder service object
- render dashboard metrics on the investments portfolio show page
- display total invested amount
- display current portfolio value using current cost basis as an initial approximation
- display unrealized profit/loss as zero until market pricing exists
- display passive income summary from investment incomes
- display asset allocation and current position breakdown by asset
- add service and request specs
- add sample investment seed data for easier local visualization
- add governance implementation plan for the issue

## Impacts

- architecture: introduces a dedicated aggregation service for dashboard data
- database: no schema change
- security: portfolio access remains scoped through current_user
- performance: dashboard uses grouped portfolio data and avoids per-asset controller queries
- tests: service and request coverage added for dashboard rendering and aggregation
- ui: upgrades the portfolio show page into an initial dashboard

## Evidence

- test results:
  - bundle exec rspec spec/services/investments/portfolio_dashboard_builder_spec.rb
  - bundle exec rspec spec/requests/investments/portfolios_spec.rb
  - all examples passing locally

## Notes

- current portfolio value and unrealized profit/loss are filled using the best approximation available today
- market price integration is still out of scope for this milestone

## Checklist

- [x] Tests passed
- [x] References checked
- [x] Security review completed
- [x] No critical warnings remain