### PR TITLE
Add portfolio allocation by category

### DIFF
--- a/app/services/investments/portfolio_dashboard_builder.rb
+++ b/app/services/investments/portfolio_dashboard_builder.rb
@@ -10,6 +10,14 @@ module Investments
       keyword_init: true
     )
 
+    CategoryAllocationEntry = Struct.new(
+      :category,
+      :label,
+      :invested_amount,
+      :allocation_percentage,
+      keyword_init: true
+    )
+
     Result = Struct.new(
       :portfolio,
       :total_invested_amount,
@@ -19,6 +27,7 @@ module Investments
       :last_transaction_date,
       :recent_transactions,
       :asset_entries,
+      :category_allocations,
       keyword_init: true
     )
 
@@ -40,6 +49,7 @@ module Investments
 
       total_invested_amount = base_entries.sum { |entry| entry.invested_amount }
       asset_entries = attach_allocation(base_entries, total_invested_amount)
+      category_allocations = build_category_allocations(asset_entries, total_invested_amount)
 
       sorted_transactions = transactions.sort_by(&:date)
 
@@ -51,7 +61,8 @@ module Investments
         passive_income_summary: incomes.sum(&:net_amount),
         last_transaction_date: sorted_transactions.last&.date,
         recent_transactions: sorted_transactions.last(3).reverse,
-        asset_entries: asset_entries.sort_by { |entry| [-entry.invested_amount, entry.asset.symbol] }
+        asset_entries: asset_entries.sort_by { |entry| [-entry.invested_amount, entry.asset.symbol] },
+        category_allocations: category_allocations
       )
     end
 
@@ -104,15 +115,36 @@ module Investments
 
     def attach_allocation(entries, total_invested_amount)
       entries.map do |entry|
-        entry.allocation_percentage =
-          if total_invested_amount.zero?
-            ZERO
-          else
-            (entry.invested_amount / total_invested_amount) * 100
-          end
+        entry.allocation_percentage = allocation_percentage_for(entry.invested_amount, total_invested_amount)
 
         entry
       end
+    end
+
+    def build_category_allocations(entries, total_invested_amount)
+      entries
+        .group_by { |entry| entry.asset.category }
+        .map do |category, category_entries|
+          invested_amount = category_entries.sum(&:invested_amount)
+
+          CategoryAllocationEntry.new(
+            category: category,
+            label: human_category(category),
+            invested_amount: invested_amount,
+            allocation_percentage: allocation_percentage_for(invested_amount, total_invested_amount)
+          )
+        end
+        .sort_by { |entry| [-entry.invested_amount, entry.label] }
+    end
+
+    def allocation_percentage_for(amount, total_amount)
+      return ZERO if total_amount.zero?
+
+      (amount / total_amount) * 100
+    end
+
+    def human_category(category)
+      I18n.t("activerecord.attributes.investments/asset.categories.#{category}")
     end
 
     def average_price_for(quantity, total_cost)

--- a/app/views/investments/portfolios/show.html.erb
+++ b/app/views/investments/portfolios/show.html.erb
@@ -1,28 +1,28 @@
-<div class="container mt-2 max-w-7xl">
+<div class="container max-w-7xl">
 
   <div class="mt-6 overflow-hidden rounded-3xl border border-gray-400 bg-white shadow-sm">
-    <div class="border-b border-gray-100 bg-gradient-to-r from-slate-50 to-white px-6 py-6 lg:px-8 lg:py-7">
-      <div class="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+    <div class="border-b border-gray-100 bg-gradient-to-r from-slate-50 to-white px-6 py-5 lg:px-8 lg:py-5.5">
+      <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Portfolio Dashboard</p>
-          <div class="mb-4">
+          <div class="mt-1">
             <%= link_to investments_portfolios_path,
                 class: "inline-flex items-center gap-2 text-sm text-slate-500 hover:text-slate-700" do %>
               <i class="fa-solid fa-arrow-left"></i>
               Voltar para portfolios
             <% end %>
           </div>
-          <h1 class="mt-2 text-3xl font-semibold text-gray-900"><%= @portfolio.name %></h1>
-          <div class="mt-3 space-y-1">
+          <h1 class="mt-3 text-3xl font-semibold text-gray-900"><%= @portfolio.name %></h1>
+          <div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-gray-500">
             <%= link_to investments_transactions_path,
               class: "inline-flex items-center gap-2 rounded-full bg-green-700 px-4 py-2 text-sm text-white text-decoration-none transition hover:bg-gray-700" do %>
-    <i class="fa-solid fa-circle-right"></i>Ver transações
-  <% end %>
-            <p class="text-sm text-gray-500">Criado em <%= l(@portfolio.created_at.to_date) %></p>
+              <i class="fa-solid fa-circle-right"></i>Ver transações
+            <% end %>
+            <p>Criado em <%= l(@portfolio.created_at.to_date) %></p>
           </div>
         </div>
 
-        <div class="rounded-2xl border border-amber-500 bg-amber-50 px-4 py-3.5 text-sm leading-6 text-amber-800 lg:max-w-md">
+        <div class="rounded-2xl border border-amber-500 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-800 lg:max-w-sm">
           Valor atual e lucro/prejuizo usam custo medio como aproximacao ate a integracao com cotacoes de mercado.
         </div>
       </div>
@@ -176,6 +176,42 @@
             <% end %>
           </div>
         </div>
+      </div>
+
+      <div class="mt-6 rounded-2xl border border-gray-400 bg-white p-4 lg:p-5">
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold text-gray-900">Alocacao por categoria</h2>
+          <span class="text-sm text-gray-500"><%= @dashboard.category_allocations.count %> categorias</span>
+        </div>
+
+        <% if @dashboard.category_allocations.any? %>
+          <div class="mt-4 space-y-2.5">
+            <% @dashboard.category_allocations.each do |allocation| %>
+              <div class="rounded-xl border border-gray-100 bg-slate-50 px-3 py-2.5">
+                <div class="flex items-center justify-between gap-4">
+                  <div>
+                    <p class="font-medium text-gray-900"><%= allocation.label %></p>
+                    <p class="text-sm text-gray-500">
+                      <%= number_to_currency(allocation.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %>
+                    </p>
+                  </div>
+
+                  <span class="text-sm font-medium text-gray-700">
+                    <%= number_with_precision(allocation.allocation_percentage, precision: 2) %>%
+                  </span>
+                </div>
+
+                <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
+                  <div class="h-full rounded-full bg-emerald-600" style="width: <%= [allocation.allocation_percentage.to_f.round(2), 100].min %>%"></div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-gray-600">
+            Nenhuma alocacao por categoria disponivel para este portfolio.
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
 
   <body>
     <%= render "shared/navbar" %>
-    <main class="container mx-auto mt-10 px-5 flex">
+    <main class="container mx-auto mt-5 px-5 flex">
       <%= yield %>
     </main>
   </body>

--- a/docs/governance/issue-63-implementation-plan.md
+++ b/docs/governance/issue-63-implementation-plan.md
@@ -1,0 +1,44 @@
+# Issue 63 Implementation Plan
+
+## Objective
+
+Add a portfolio dashboard view that summarizes asset allocation by category based on the current invested positions of the portfolio.
+
+## Affected Files
+
+- `app/services/investments/portfolio_dashboard_builder.rb`
+- `app/views/investments/portfolios/show.html.erb`
+- `spec/services/investments/portfolio_dashboard_builder_spec.rb`
+- `spec/requests/investments/portfolios_spec.rb`
+
+## Risks
+
+- Calculating allocation from raw transactions instead of current positions and producing inconsistent totals
+- Duplicating aggregation logic in the view instead of centralizing it in the dashboard builder
+- Rendering category labels inconsistently with the existing asset translations
+
+## Technical Strategy
+
+Extend the portfolio dashboard builder to expose a category-level allocation summary derived from the already computed asset entries.
+
+Group asset entries by `asset.category`, sum each category invested amount, and calculate the percentage over the portfolio `total_invested_amount`.
+
+Render a new dashboard section in the portfolio show page using the existing visual language and an empty state when there are no positions.
+
+## Database Impact
+
+No database changes are required for this issue.
+
+The existing asset category enum and portfolio transaction data already support the feature.
+
+## Required Tests
+
+- service specs for category aggregation totals and percentages
+- request specs for dashboard rendering with allocation by category
+- empty-state validation for portfolios without positions
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-06-16

--- a/spec/requests/investments/portfolios_spec.rb
+++ b/spec/requests/investments/portfolios_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe "Investments::Portfolios", type: :request do
     )
   end
 
+  let!(:stock_asset) do
+    Investments::Asset.create!(
+      name: "Banco do Brasil",
+      symbol: "BBAS3",
+      category: :stock,
+      currency: "BRL"
+    )
+  end
+
   before do
     sign_in user
   end
@@ -79,6 +88,16 @@ RSpec.describe "Investments::Portfolios", type: :request do
         tax_amount: 0,
         payment_date: Date.current
       )
+
+      Investments::Transaction.create!(
+        portfolio: portfolio,
+        asset: stock_asset,
+        transaction_type: :buy,
+        quantity: 1,
+        price: 30,
+        fees: 0,
+        date: Date.current
+      )
     end
 
     it "renders the initial dashboard metrics for the portfolio" do
@@ -88,7 +107,10 @@ RSpec.describe "Investments::Portfolios", type: :request do
       expect(response.body).to include("Portfolio Dashboard")
       expect(response.body).to include("Total investido")
       expect(response.body).to include("Renda passiva liquida")
+      expect(response.body).to include("Alocacao por categoria")
       expect(response.body).to include("AAPL")
+      expect(response.body).to include("Internacional")
+      expect(response.body).to include("Ações")
     end
 
     it "returns not found for a portfolio from another user" do

--- a/spec/services/investments/portfolio_dashboard_builder_spec.rb
+++ b/spec/services/investments/portfolio_dashboard_builder_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Investments::PortfolioDashboardBuilder do
     expect(dashboard.unrealized_profit_loss).to eq(BigDecimal("0"))
     expect(dashboard.passive_income_summary).to eq(BigDecimal("0"))
     expect(dashboard.asset_entries).to be_empty
+    expect(dashboard.category_allocations).to be_empty
   end
 
   it "builds asset entries and portfolio totals from current positions" do
@@ -68,6 +69,37 @@ RSpec.describe Investments::PortfolioDashboardBuilder do
     expect(fii_entry.quantity).to eq(BigDecimal("20"))
     expect(fii_entry.average_price).to eq(BigDecimal("10"))
     expect(fii_entry.invested_amount).to eq(BigDecimal("200"))
+  end
+
+  it "builds category allocations from the current invested positions" do
+    local_stock_asset = Investments::Asset.create!(
+      name: "Banco do Brasil",
+      symbol: "BBAS3",
+      category: :stock,
+      currency: "BRL"
+    )
+
+    create_transaction(stock_asset, :buy, quantity: 10, price: 20, fees: 0, date: Date.new(2026, 1, 1))
+    create_transaction(fii_asset, :buy, quantity: 5, price: 10, fees: 0, date: Date.new(2026, 1, 2))
+    create_transaction(local_stock_asset, :buy, quantity: 3, price: 50, fees: 0, date: Date.new(2026, 1, 3))
+
+    expect(dashboard.category_allocations.map(&:category)).to eq(%w[international stock fii])
+
+    international_allocation = dashboard.category_allocations.find { |entry| entry.category == "international" }
+    stock_allocation = dashboard.category_allocations.find { |entry| entry.category == "stock" }
+    fii_allocation = dashboard.category_allocations.find { |entry| entry.category == "fii" }
+
+    expect(international_allocation.label).to eq("Internacional")
+    expect(international_allocation.invested_amount).to eq(BigDecimal("200"))
+    expect(international_allocation.allocation_percentage).to eq(BigDecimal("50"))
+
+    expect(stock_allocation.label).to eq("Ações")
+    expect(stock_allocation.invested_amount).to eq(BigDecimal("150"))
+    expect(stock_allocation.allocation_percentage).to eq(BigDecimal("37.5"))
+
+    expect(fii_allocation.label).to eq("Fundos Imobiliários")
+    expect(fii_allocation.invested_amount).to eq(BigDecimal("50"))
+    expect(fii_allocation.allocation_percentage).to eq(BigDecimal("12.5"))
   end
 
   it "calculates passive income summary from net amounts" do


### PR DESCRIPTION
## Summary
Add category-level allocation to the investments portfolio dashboard so users can see how invested capital is distributed across asset categories.

## Motivation
The portfolio dashboard already summarized positions by asset, but it did not provide a higher-level allocation view. This issue closes that gap with an aggregated category section and a tighter dashboard layout.

## Main Changes
- extend `Investments::PortfolioDashboardBuilder` to expose `category_allocations`
- group current invested positions by asset category and calculate allocation percentages
- render a compact `Alocacao por categoria` section on the portfolio dashboard
- tighten the portfolio header spacing and reduce excess vertical whitespace
- document the implementation plan under `docs/governance/issue-63-implementation-plan.md`
- add service and request coverage for category allocation and dashboard rendering

## Impacts
- portfolio dashboards now show allocation by category based on invested capital
- no database or route changes were required
- existing portfolio calculations remain scoped to the authenticated user data

## Validation
- `bundle exec rspec spec/services/investments/portfolio_dashboard_builder_spec.rb spec/requests/investments/portfolios_spec.rb`
- result: `13 examples, 0 failures`

## Notes
- an existing ViewComponent deprecation warning for Ruby versions lower than 3.2 still appears during test runs and was not introduced by this change.
