### PR TITLE
Add portfolio allocation by subcategory

### DIFF
--- a/app/services/investments/portfolio_dashboard_builder.rb
+++ b/app/services/investments/portfolio_dashboard_builder.rb
@@ -18,6 +18,14 @@ module Investments
       keyword_init: true
     )
 
+    SubcategoryAllocationEntry = Struct.new(
+      :subcategory,
+      :label,
+      :invested_amount,
+      :allocation_percentage,
+      keyword_init: true
+    )
+
     Result = Struct.new(
       :portfolio,
       :total_invested_amount,
@@ -28,6 +36,7 @@ module Investments
       :recent_transactions,
       :asset_entries,
       :category_allocations,
+      :subcategory_allocations,
       keyword_init: true
     )
 
@@ -50,6 +59,7 @@ module Investments
       total_invested_amount = base_entries.sum { |entry| entry.invested_amount }
       asset_entries = attach_allocation(base_entries, total_invested_amount)
       category_allocations = build_category_allocations(asset_entries, total_invested_amount)
+      subcategory_allocations = build_subcategory_allocations(asset_entries, total_invested_amount)
 
       sorted_transactions = transactions.sort_by(&:date)
 
@@ -62,7 +72,8 @@ module Investments
         last_transaction_date: sorted_transactions.last&.date,
         recent_transactions: sorted_transactions.last(3).reverse,
         asset_entries: asset_entries.sort_by { |entry| [-entry.invested_amount, entry.asset.symbol] },
-        category_allocations: category_allocations
+        category_allocations: category_allocations,
+        subcategory_allocations: subcategory_allocations
       )
     end
 
@@ -137,6 +148,22 @@ module Investments
         .sort_by { |entry| [-entry.invested_amount, entry.label] }
     end
 
+    def build_subcategory_allocations(entries, total_invested_amount)
+      entries
+        .group_by { |entry| entry.asset.subcategory.presence }
+        .map do |subcategory, subcategory_entries|
+          invested_amount = subcategory_entries.sum(&:invested_amount)
+
+          SubcategoryAllocationEntry.new(
+            subcategory: subcategory,
+            label: human_subcategory(subcategory),
+            invested_amount: invested_amount,
+            allocation_percentage: allocation_percentage_for(invested_amount, total_invested_amount)
+          )
+        end
+        .sort_by { |entry| [-entry.invested_amount, entry.label] }
+    end
+
     def allocation_percentage_for(amount, total_amount)
       return ZERO if total_amount.zero?
 
@@ -145,6 +172,12 @@ module Investments
 
     def human_category(category)
       I18n.t("activerecord.attributes.investments/asset.categories.#{category}")
+    end
+
+    def human_subcategory(subcategory)
+      return "Sem subcategoria" if subcategory.blank?
+
+      I18n.t("activerecord.attributes.investments/asset.subcategories.#{subcategory}")
     end
 
     def average_price_for(quantity, total_cost)

--- a/app/views/investments/portfolios/show.html.erb
+++ b/app/views/investments/portfolios/show.html.erb
@@ -178,40 +178,78 @@
         </div>
       </div>
 
-      <div class="mt-6 rounded-2xl border border-gray-400 bg-white p-4 lg:p-5">
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-semibold text-gray-900">Alocacao por categoria</h2>
-          <span class="text-sm text-gray-500"><%= @dashboard.category_allocations.count %> categorias</span>
-        </div>
+      <div class="mt-6 grid gap-4 xl:grid-cols-2">
+        <div class="rounded-2xl border border-gray-400 bg-white p-4 lg:p-5">
+          <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-gray-900">Alocacao por categoria</h2>
+            <span class="text-sm text-gray-500"><%= @dashboard.category_allocations.count %> categorias</span>
+          </div>
 
-        <% if @dashboard.category_allocations.any? %>
-          <div class="mt-4 space-y-2.5">
-            <% @dashboard.category_allocations.each do |allocation| %>
-              <div class="rounded-xl border border-gray-100 bg-slate-50 px-3 py-2.5">
-                <div class="flex items-center justify-between gap-4">
-                  <div>
-                    <p class="font-medium text-gray-900"><%= allocation.label %></p>
-                    <p class="text-sm text-gray-500">
-                      <%= number_to_currency(allocation.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %>
-                    </p>
+          <% if @dashboard.category_allocations.any? %>
+            <div class="mt-4 space-y-2.5">
+              <% @dashboard.category_allocations.each do |allocation| %>
+                <div class="rounded-xl border border-gray-100 bg-slate-50 px-3 py-2.5">
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="font-medium text-gray-900"><%= allocation.label %></p>
+                      <p class="text-sm text-gray-500">
+                        <%= number_to_currency(allocation.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %>
+                      </p>
+                    </div>
+
+                    <span class="text-sm font-medium text-gray-700">
+                      <%= number_with_precision(allocation.allocation_percentage, precision: 2) %>%
+                    </span>
                   </div>
 
-                  <span class="text-sm font-medium text-gray-700">
-                    <%= number_with_precision(allocation.allocation_percentage, precision: 2) %>%
-                  </span>
+                  <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
+                    <div class="h-full rounded-full bg-emerald-600" style="width: <%= [allocation.allocation_percentage.to_f.round(2), 100].min %>%"></div>
+                  </div>
                 </div>
+              <% end %>
+            </div>
+          <% else %>
+            <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-gray-600">
+              Nenhuma alocacao por categoria disponivel para este portfolio.
+            </div>
+          <% end %>
+        </div>
 
-                <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
-                  <div class="h-full rounded-full bg-emerald-600" style="width: <%= [allocation.allocation_percentage.to_f.round(2), 100].min %>%"></div>
+        <div class="rounded-2xl border border-gray-400 bg-white p-4 lg:p-5">
+          <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-gray-900">Alocacao por subcategoria</h2>
+            <span class="text-sm text-gray-500"><%= @dashboard.subcategory_allocations.count %> grupos</span>
+          </div>
+
+          <% if @dashboard.subcategory_allocations.any? %>
+            <div class="mt-4 space-y-2.5">
+              <% @dashboard.subcategory_allocations.each do |allocation| %>
+                <div class="rounded-xl border border-gray-100 bg-slate-50 px-3 py-2.5">
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="font-medium text-gray-900"><%= allocation.label %></p>
+                      <p class="text-sm text-gray-500">
+                        <%= number_to_currency(allocation.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %>
+                      </p>
+                    </div>
+
+                    <span class="text-sm font-medium text-gray-700">
+                      <%= number_with_precision(allocation.allocation_percentage, precision: 2) %>%
+                    </span>
+                  </div>
+
+                  <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
+                    <div class="h-full rounded-full bg-cyan-600" style="width: <%= [allocation.allocation_percentage.to_f.round(2), 100].min %>%"></div>
+                  </div>
                 </div>
-              </div>
-            <% end %>
-          </div>
-        <% else %>
-          <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-gray-600">
-            Nenhuma alocacao por categoria disponivel para este portfolio.
-          </div>
-        <% end %>
+              <% end %>
+            </div>
+          <% else %>
+            <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-gray-600">
+              Nenhuma alocacao por subcategoria disponivel para este portfolio.
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/docs/governance/issue-64-implementation-plan.md
+++ b/docs/governance/issue-64-implementation-plan.md
@@ -1,0 +1,46 @@
+# Issue 64 Implementation Plan
+
+## Objective
+
+Add a portfolio dashboard view that summarizes asset allocation by subcategory based on the current invested positions of the portfolio.
+
+## Affected Files
+
+- `app/services/investments/portfolio_dashboard_builder.rb`
+- `app/views/investments/portfolios/show.html.erb`
+- `spec/services/investments/portfolio_dashboard_builder_spec.rb`
+- `spec/requests/investments/portfolios_spec.rb`
+
+## Risks
+
+- Hiding invested capital from assets without a defined subcategory
+- Duplicating subcategory aggregation logic in the view instead of keeping it in the dashboard builder
+- Rendering subcategory labels inconsistently with the existing asset translations
+
+## Technical Strategy
+
+Extend the portfolio dashboard builder to expose a subcategory-level allocation summary derived from the current asset entries.
+
+Group asset entries by `asset.subcategory`, sum invested capital for each group, and calculate the percentage over the portfolio `total_invested_amount`.
+
+Assets without a defined subcategory must remain visible under a `Sem subcategoria` bucket so the dashboard reflects the full invested amount.
+
+Render a compact dashboard section for subcategory allocation following the existing portfolio dashboard visual language.
+
+## Database Impact
+
+No database changes are required for this issue.
+
+The existing asset subcategory enum and portfolio transaction data already support the feature.
+
+## Required Tests
+
+- service specs for subcategory aggregation totals and percentages
+- request specs for dashboard rendering with allocation by subcategory
+- empty-state validation for portfolios without positions
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-06-16

--- a/spec/requests/investments/portfolios_spec.rb
+++ b/spec/requests/investments/portfolios_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Investments::Portfolios", type: :request do
       name: "Apple Inc.",
       symbol: "AAPL",
       category: :international,
+      subcategory: :technology,
       currency: "USD"
     )
   end
@@ -38,6 +39,16 @@ RSpec.describe "Investments::Portfolios", type: :request do
       name: "Banco do Brasil",
       symbol: "BBAS3",
       category: :stock,
+      subcategory: :banks,
+      currency: "BRL"
+    )
+  end
+
+  let!(:fixed_income_asset) do
+    Investments::Asset.create!(
+      name: "Tesouro Selic",
+      symbol: "SELIC2029",
+      category: :fixed_income,
       currency: "BRL"
     )
   end
@@ -98,6 +109,16 @@ RSpec.describe "Investments::Portfolios", type: :request do
         fees: 0,
         date: Date.current
       )
+
+      Investments::Transaction.create!(
+        portfolio: portfolio,
+        asset: fixed_income_asset,
+        transaction_type: :buy,
+        quantity: 1,
+        price: 15,
+        fees: 0,
+        date: Date.current
+      )
     end
 
     it "renders the initial dashboard metrics for the portfolio" do
@@ -108,9 +129,13 @@ RSpec.describe "Investments::Portfolios", type: :request do
       expect(response.body).to include("Total investido")
       expect(response.body).to include("Renda passiva liquida")
       expect(response.body).to include("Alocacao por categoria")
+      expect(response.body).to include("Alocacao por subcategoria")
       expect(response.body).to include("AAPL")
       expect(response.body).to include("Internacional")
       expect(response.body).to include("Ações")
+      expect(response.body).to include("Tecnologia")
+      expect(response.body).to include("Bancos")
+      expect(response.body).to include("Sem subcategoria")
     end
 
     it "returns not found for a portfolio from another user" do

--- a/spec/services/investments/portfolio_dashboard_builder_spec.rb
+++ b/spec/services/investments/portfolio_dashboard_builder_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Investments::PortfolioDashboardBuilder do
       name: "Apple Inc.",
       symbol: "AAPL",
       category: :international,
+      subcategory: :technology,
       currency: "USD"
     )
   end
@@ -30,6 +31,7 @@ RSpec.describe Investments::PortfolioDashboardBuilder do
       name: "XP Malls",
       symbol: "XPML11",
       category: :fii,
+      subcategory: :brick,
       currency: "BRL"
     )
   end
@@ -43,6 +45,7 @@ RSpec.describe Investments::PortfolioDashboardBuilder do
     expect(dashboard.passive_income_summary).to eq(BigDecimal("0"))
     expect(dashboard.asset_entries).to be_empty
     expect(dashboard.category_allocations).to be_empty
+    expect(dashboard.subcategory_allocations).to be_empty
   end
 
   it "builds asset entries and portfolio totals from current positions" do
@@ -100,6 +103,52 @@ RSpec.describe Investments::PortfolioDashboardBuilder do
     expect(fii_allocation.label).to eq("Fundos Imobiliários")
     expect(fii_allocation.invested_amount).to eq(BigDecimal("50"))
     expect(fii_allocation.allocation_percentage).to eq(BigDecimal("12.5"))
+  end
+
+  it "builds subcategory allocations from the current invested positions" do
+    local_stock_asset = Investments::Asset.create!(
+      name: "Banco do Brasil",
+      symbol: "BBAS3",
+      category: :stock,
+      subcategory: :banks,
+      currency: "BRL"
+    )
+
+    no_subcategory_asset = Investments::Asset.create!(
+      name: "Tesouro Selic",
+      symbol: "SELIC2029",
+      category: :fixed_income,
+      currency: "BRL"
+    )
+
+    create_transaction(stock_asset, :buy, quantity: 10, price: 20, fees: 0, date: Date.new(2026, 1, 1))
+    create_transaction(fii_asset, :buy, quantity: 5, price: 10, fees: 0, date: Date.new(2026, 1, 2))
+    create_transaction(local_stock_asset, :buy, quantity: 3, price: 50, fees: 0, date: Date.new(2026, 1, 3))
+    create_transaction(no_subcategory_asset, :buy, quantity: 2, price: 25, fees: 0, date: Date.new(2026, 1, 4))
+
+    expected_total = BigDecimal("450")
+
+    expect(dashboard.subcategory_allocations.map(&:label)).to eq(
+      ["Tecnologia", "Bancos", "Sem subcategoria", "Tijolo"]
+    )
+
+    technology_allocation = dashboard.subcategory_allocations.find { |entry| entry.subcategory == "technology" }
+    banks_allocation = dashboard.subcategory_allocations.find { |entry| entry.subcategory == "banks" }
+    brick_allocation = dashboard.subcategory_allocations.find { |entry| entry.subcategory == "brick" }
+    uncategorized_allocation = dashboard.subcategory_allocations.find { |entry| entry.subcategory.nil? }
+
+    expect(technology_allocation.invested_amount).to eq(BigDecimal("200"))
+    expect(technology_allocation.allocation_percentage).to eq((BigDecimal("200") / expected_total) * 100)
+
+    expect(banks_allocation.invested_amount).to eq(BigDecimal("150"))
+    expect(banks_allocation.allocation_percentage).to eq((BigDecimal("150") / expected_total) * 100)
+
+    expect(brick_allocation.invested_amount).to eq(BigDecimal("50"))
+    expect(brick_allocation.allocation_percentage).to eq((BigDecimal("50") / expected_total) * 100)
+
+    expect(uncategorized_allocation.label).to eq("Sem subcategoria")
+    expect(uncategorized_allocation.invested_amount).to eq(BigDecimal("50"))
+    expect(uncategorized_allocation.allocation_percentage).to eq((BigDecimal("50") / expected_total) * 100)
   end
 
   it "calculates passive income summary from net amounts" do


### PR DESCRIPTION
## Summary
Add subcategory-level allocation to the investments portfolio dashboard so users can inspect a more detailed distribution of invested capital.

## Motivation
The dashboard already exposed allocation by category, but it still lacked a more granular view of portfolio composition. This change adds subcategory aggregation while keeping assets without a subcategory visible under a dedicated bucket.

## Main Changes
- extend `Investments::PortfolioDashboardBuilder` to expose `subcategory_allocations`
- group current invested positions by asset subcategory and calculate allocation percentages
- keep assets without a subcategory visible as `Sem subcategoria`
- render category and subcategory allocation blocks side by side on larger screens
- document the implementation plan under `docs/governance/issue-64-implementation-plan.md`
- add service and request coverage for subcategory allocation and dashboard rendering

## Impacts
- portfolio dashboards now show a more detailed allocation view by subcategory
- assets without a subcategory are still counted in the full invested capital
- no database or route changes were required

## Validation
- `bundle exec rspec spec/services/investments/portfolio_dashboard_builder_spec.rb spec/requests/investments/portfolios_spec.rb`
- result: `14 examples, 0 failures`

## Notes
- an existing ViewComponent deprecation warning for Ruby versions lower than 3.2 still appears during test runs and was not introduced by this change.
