### PR TITLE
[codex] Add market data provider abstraction

### DIFF
--- a/app/services/market_data/asset_lookup_service.rb
+++ b/app/services/market_data/asset_lookup_service.rb
@@ -1,0 +1,20 @@
+module MarketData
+  class AssetLookupService
+    def initialize(provider: NullProvider.new)
+      @provider = provider
+    end
+
+    # Normalizes the ticker before delegating so future providers can receive a stable input shape.
+    def call(symbol:)
+      provider.lookup_asset(symbol: normalize_symbol(symbol))
+    end
+
+    private
+
+    attr_reader :provider
+
+    def normalize_symbol(symbol)
+      symbol.to_s.strip.upcase
+    end
+  end
+end

--- a/docs/code-overview.md
+++ b/docs/code-overview.md
@@ -20,6 +20,10 @@ Its goal is to help contributors understand where the main responsibilities live
   operation history connecting user portfolios to global investment assets
 - `app/models/investments/income.rb`
   income history linked to a portfolio context and the asset that generated the payment
+- `lib/market_data/*`
+  provider abstraction and normalized service boundary for future external market data integrations
+- `app/services/market_data/asset_lookup_service.rb`
+  application-facing entrypoint for asset lookup so controllers and future flows do not call providers directly
 
 ## Authentication And User Scope
 

--- a/docs/governance/issue-72-implementation-plan.md
+++ b/docs/governance/issue-72-implementation-plan.md
@@ -1,0 +1,54 @@
+# Issue 72 Implementation Plan
+
+## Objective
+
+Create a provider abstraction layer for external market data so the investments domain depends on a stable interface instead of a concrete implementation.
+
+## Affected Files
+
+- `lib/market_data/provider.rb`
+- `lib/market_data/asset_data.rb`
+- `lib/market_data/errors.rb`
+- `lib/market_data/null_provider.rb`
+- `app/services/market_data/asset_lookup_service.rb`
+- `docs/code-overview.md`
+- `spec/lib/market_data/provider_spec.rb`
+- `spec/lib/market_data/null_provider_spec.rb`
+- `spec/services/market_data/asset_lookup_service_spec.rb`
+
+## Risks
+
+- Over-designing the abstraction before the first provider exists
+- Blurring the boundary between provider contract and application service responsibility
+- Locking future provider integrations into an interface that is too narrow or too provider-specific
+
+## Technical Strategy
+
+Create a `MarketData` namespace with:
+
+- a provider contract defining the expected operations
+- a value object for normalized asset lookup results
+- domain-specific error classes
+- a null provider used when no real provider is configured yet
+
+Add `MarketData::AssetLookupService` as the application-facing lookup entrypoint so future features use the service instead of calling providers directly.
+
+This issue will not introduce any HTTP client or external integration.
+
+## Database Impact
+
+No database changes are required for this issue.
+
+The work is limited to architecture and service-layer abstractions.
+
+## Required Tests
+
+- provider contract specs
+- null provider specs
+- asset lookup service specs with injected test doubles
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-07-01

--- a/lib/market_data/asset_data.rb
+++ b/lib/market_data/asset_data.rb
@@ -1,0 +1,11 @@
+module MarketData
+  AssetData = Struct.new(
+    :symbol,
+    :name,
+    :currency,
+    :category,
+    :subcategory,
+    :active,
+    keyword_init: true
+  )
+end

--- a/lib/market_data/configuration_error.rb
+++ b/lib/market_data/configuration_error.rb
@@ -1,0 +1,3 @@
+module MarketData
+  class ConfigurationError < ProviderError; end
+end

--- a/lib/market_data/error.rb
+++ b/lib/market_data/error.rb
@@ -1,0 +1,3 @@
+module MarketData
+  class Error < StandardError; end
+end

--- a/lib/market_data/not_found_error.rb
+++ b/lib/market_data/not_found_error.rb
@@ -1,0 +1,3 @@
+module MarketData
+  class NotFoundError < ProviderError; end
+end

--- a/lib/market_data/null_provider.rb
+++ b/lib/market_data/null_provider.rb
@@ -1,0 +1,19 @@
+module MarketData
+  class NullProvider < Provider
+    # Explicit fallback used while no external provider is configured.
+    # Failing fast here keeps the service boundary available without silently masking setup gaps.
+    MESSAGE = "No market data provider configured".freeze
+
+    def lookup_asset(symbol:)
+      raise ConfigurationError, MESSAGE
+    end
+
+    def fetch_asset_metadata(symbol:)
+      raise ConfigurationError, MESSAGE
+    end
+
+    def fetch_price(symbol:)
+      raise ConfigurationError, MESSAGE
+    end
+  end
+end

--- a/lib/market_data/provider.rb
+++ b/lib/market_data/provider.rb
@@ -1,0 +1,17 @@
+module MarketData
+  class Provider
+    # Base contract for market data integrations.
+    # Application services should depend on this interface instead of a concrete API client.
+    def lookup_asset(symbol:)
+      raise NotImplementedError, "#{self.class.name} must implement #lookup_asset"
+    end
+
+    def fetch_asset_metadata(symbol:)
+      raise NotImplementedError, "#{self.class.name} must implement #fetch_asset_metadata"
+    end
+
+    def fetch_price(symbol:)
+      raise NotImplementedError, "#{self.class.name} must implement #fetch_price"
+    end
+  end
+end

--- a/lib/market_data/provider_error.rb
+++ b/lib/market_data/provider_error.rb
@@ -1,0 +1,3 @@
+module MarketData
+  class ProviderError < Error; end
+end

--- a/spec/lib/market_data/null_provider_spec.rb
+++ b/spec/lib/market_data/null_provider_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe MarketData::NullProvider do
+  subject(:provider) { described_class.new }
+
+  it "raises a configuration error for asset lookup" do
+    expect { provider.lookup_asset(symbol: "AAPL") }
+      .to raise_error(MarketData::ConfigurationError, "No market data provider configured")
+  end
+
+  it "raises a configuration error for metadata retrieval" do
+    expect { provider.fetch_asset_metadata(symbol: "AAPL") }
+      .to raise_error(MarketData::ConfigurationError, "No market data provider configured")
+  end
+
+  it "raises a configuration error for price retrieval" do
+    expect { provider.fetch_price(symbol: "AAPL") }
+      .to raise_error(MarketData::ConfigurationError, "No market data provider configured")
+  end
+end

--- a/spec/lib/market_data/provider_spec.rb
+++ b/spec/lib/market_data/provider_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe MarketData::Provider do
+  subject(:provider) { described_class.new }
+
+  it "defines the asset lookup contract" do
+    expect { provider.lookup_asset(symbol: "AAPL") }
+      .to raise_error(NotImplementedError, /must implement #lookup_asset/)
+  end
+
+  it "defines the asset metadata contract" do
+    expect { provider.fetch_asset_metadata(symbol: "AAPL") }
+      .to raise_error(NotImplementedError, /must implement #fetch_asset_metadata/)
+  end
+
+  it "defines the price contract" do
+    expect { provider.fetch_price(symbol: "AAPL") }
+      .to raise_error(NotImplementedError, /must implement #fetch_price/)
+  end
+end

--- a/spec/services/market_data/asset_lookup_service_spec.rb
+++ b/spec/services/market_data/asset_lookup_service_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe MarketData::AssetLookupService do
+  describe "#call" do
+    it "delegates asset lookup to the injected provider with a normalized symbol" do
+      asset_data = MarketData::AssetData.new(
+        symbol: "AAPL",
+        name: "Apple Inc.",
+        currency: "USD",
+        category: "international",
+        subcategory: "technology",
+        active: true
+      )
+
+      provider = instance_double(MarketData::Provider)
+      allow(provider).to receive(:lookup_asset).with(symbol: "AAPL").and_return(asset_data)
+
+      result = described_class.new(provider: provider).call(symbol: " aapl ")
+
+      expect(result).to eq(asset_data)
+      expect(provider).to have_received(:lookup_asset).with(symbol: "AAPL")
+    end
+
+    it "uses the null provider by default" do
+      expect { described_class.new.call(symbol: "AAPL") }
+        .to raise_error(MarketData::ConfigurationError, "No market data provider configured")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Create the initial MarketData abstraction layer so the investments domain can depend on a stable provider contract instead of a concrete external integration.

## Motivation
Upcoming market data features need a clean architectural boundary before we plug in a real provider or expose auto-fill behavior in the asset flow. This change creates that boundary first.

## Main Changes
- add the `MarketData::Provider` contract
- add normalized asset lookup payload support through `MarketData::AssetData`
- add dedicated market data error classes
- add `MarketData::NullProvider` as the default fail-fast fallback when no provider is configured
- add `MarketData::AssetLookupService` as the application-facing lookup entrypoint
- document the new layer in `docs/code-overview.md` and register the implementation plan in `docs/governance/issue-72-implementation-plan.md`
- add focused specs for the provider contract, null provider, and asset lookup service

## Impacts
- the investments domain now has a stable service boundary for future provider integrations
- no external API was introduced in this issue
- no database or route changes were required

## Validation
- `bundle exec rspec spec/lib/market_data/provider_spec.rb spec/lib/market_data/null_provider_spec.rb spec/services/market_data/asset_lookup_service_spec.rb`
- result: `8 examples, 0 failures`

## Notes
- an existing ViewComponent deprecation warning for Ruby versions lower than 3.2 still appears during test runs and was not introduced by this change.
