### PR TITLE
[codex] Add first BRAPI market data provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mswin mswin64 mingw x64_mingw ]
   gem 'rspec-rails'
+  gem "dotenv-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
+    dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     drb (2.2.3)
     erb (4.0.4)
       cgi (>= 0.3.3)
@@ -335,6 +339,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  dotenv-rails
   error_highlight (>= 0.4.0)
   font-awesome-sass
   importmap-rails

--- a/app/services/market_data/asset_lookup_service.rb
+++ b/app/services/market_data/asset_lookup_service.rb
@@ -1,6 +1,6 @@
 module MarketData
   class AssetLookupService
-    def initialize(provider: NullProvider.new)
+    def initialize(provider: Providers::BrapiProvider.new)
       @provider = provider
     end
 

--- a/docs/code-overview.md
+++ b/docs/code-overview.md
@@ -24,6 +24,8 @@ Its goal is to help contributors understand where the main responsibilities live
   provider abstraction and normalized service boundary for future external market data integrations
 - `app/services/market_data/asset_lookup_service.rb`
   application-facing entrypoint for asset lookup so controllers and future flows do not call providers directly
+- `lib/market_data/providers/brapi_provider.rb`
+  first concrete provider implementation with Brazil-first asset metadata lookup
 
 ## Authentication And User Scope
 
@@ -42,6 +44,11 @@ Its goal is to help contributors understand where the main responsibilities live
 - prefer explicit foreign keys for user-owned data
 - add indexes for lookup and uniqueness rules that matter to the domain
 - do not modify old migrations; create new ones instead
+
+## Local Configuration
+
+- development-only secrets may live in a local `.env` file, which is already ignored by git
+- keep a versioned `.env.example` with the variable names required to run integrations locally
 
 ## Tests
 

--- a/docs/governance/issue-75-implementation-plan.md
+++ b/docs/governance/issue-75-implementation-plan.md
@@ -1,0 +1,50 @@
+# Issue 75 Implementation Plan
+
+## Objective
+
+Implement the first concrete market data provider using the existing provider abstraction so the application can retrieve asset metadata through a real external integration.
+
+## Affected Files
+
+- `lib/market_data/providers/brapi_provider.rb`
+- `app/services/market_data/asset_lookup_service.rb`
+- `docs/code-overview.md`
+- `spec/lib/market_data/providers/brapi_provider_spec.rb`
+- `spec/services/market_data/asset_lookup_service_spec.rb`
+
+## Risks
+
+- Coupling the application to provider-specific response shapes instead of normalizing data at the boundary
+- Introducing brittle HTTP behavior or unclear errors when the provider returns incomplete or unauthorized responses
+- Using category mapping heuristics that are too aggressive for incomplete metadata
+
+## Technical Strategy
+
+Implement a first concrete provider under `MarketData::Providers` using BRAPI's documented stock quote endpoint.
+
+The provider will:
+
+- fetch asset metadata by symbol
+- normalize the response into `MarketData::AssetData`
+- translate provider failures into `MarketData` error types
+- map category only when a safe heuristic is available for the returned quote type
+
+Integrate this provider into `MarketData::AssetLookupService` as the default provider so future application flows automatically use a Brazil-first integration point.
+
+## Database Impact
+
+No database changes are required for this issue.
+
+The work is limited to service-layer integration with an external provider.
+
+## Required Tests
+
+- provider specs for successful lookup
+- provider specs for missing symbol / provider error handling
+- asset lookup service specs confirming the default provider integration
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-07-09

--- a/lib/market_data/providers/brapi_provider.rb
+++ b/lib/market_data/providers/brapi_provider.rb
@@ -1,0 +1,98 @@
+require "json"
+require "net/http"
+
+module MarketData
+  module Providers
+    class BrapiProvider < Provider
+      BASE_URL = "https://brapi.dev/api/v2".freeze
+      API_TOKEN_ENV = "BRAPI_API_TOKEN".freeze
+
+      def initialize(api_token: ENV[API_TOKEN_ENV])
+        @api_token = api_token
+      end
+
+      def lookup_asset(symbol:)
+        payload = fetch_asset_metadata(symbol: symbol)
+        metadata = payload
+
+        AssetData.new(
+          symbol: payload.fetch("symbol", symbol),
+          name: metadata["longName"].presence || metadata["name"].presence || payload.fetch("symbol", symbol),
+          currency: metadata["currency"],
+          category: map_category(metadata),
+          subcategory: nil,
+          active: active_from(metadata)
+        )
+      end
+
+      def fetch_asset_metadata(symbol:)
+        payload = get_json(
+          path: "/tickers",
+          query_params: { search: symbol }
+        )
+
+        results = payload.fetch("results", [])
+        asset_payload = results.find do |item|
+          item["symbol"].to_s.casecmp?(symbol)
+        end
+
+        raise NotFoundError, "Asset not found for symbol #{symbol}" if asset_payload.blank?
+        raise NotFoundError, "Asset not found for symbol #{symbol}" if asset_payload["longName"].blank? && asset_payload["name"].blank?
+
+        asset_payload
+      end
+
+      def fetch_price(symbol:)
+        raise NotImplementedError, "#{self.class.name} does not implement #fetch_price yet"
+      end
+
+      private
+
+      attr_reader :api_token
+
+      def get_json(path:, query_params:)
+        uri = URI("#{BASE_URL}#{path}")
+        uri.query = URI.encode_www_form(query_params)
+
+        request = Net::HTTP::Get.new(uri)
+        request["Authorization"] = "Bearer #{api_token}" if api_token.present?
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+          http.request(request)
+        end
+
+        unless response.code.to_i.between?(200, 299)
+          raise ProviderError, "BRAPI request failed with status #{response.code}"
+        end
+
+        payload = JSON.parse(response.body)
+        raise ProviderError, payload["error"] if payload["error"].present?
+
+        payload
+      rescue JSON::ParserError => e
+        raise ProviderError, "BRAPI returned invalid JSON: #{e.message}"
+      end
+
+      def map_category(metadata)
+        asset_type = metadata["assetType"].to_s.downcase
+        sub_type = metadata["subType"].to_s.downcase
+        currency = metadata["currency"].to_s.upcase
+
+        return "etf" if sub_type == "etf"
+        return "fii" if sub_type == "fii"
+        return "crypto" if asset_type.include?("crypto")
+        return "fixed_income" if sub_type.include?("fi-infra") || sub_type.include?("fi-agro")
+        return "stock" if asset_type == "stock" && currency == "BRL"
+        return "international" if asset_type == "stock"
+        return "international" if asset_type == "bdr"
+        return "etf" if asset_type == "fund" && sub_type == "etf"
+
+        nil
+      end
+
+      def active_from(metadata)
+        metadata["isActive"].nil? ? (metadata["longName"].present? || metadata["name"].present?) : metadata["isActive"]
+      end
+    end
+  end
+end

--- a/spec/lib/market_data/providers/brapi_provider_spec.rb
+++ b/spec/lib/market_data/providers/brapi_provider_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+RSpec.describe MarketData::Providers::BrapiProvider do
+  subject(:provider) { described_class.new(api_token: "test-token") }
+
+  describe "#lookup_asset" do
+    it "returns normalized asset metadata for a Brazilian stock" do
+      response = instance_double(
+        Net::HTTPOK,
+        code: "200",
+        body: {
+          "results" => [
+            {
+              "symbol" => "PETR4",
+              "name" => "PETROLEO BRASILEIRO S.A. PETROBRAS",
+              "longName" => "Petroleo Brasileiro SA Pfd",
+              "assetType" => "stock",
+              "subType" => "stock",
+              "exchange" => "B3",
+              "currency" => "BRL",
+              "sector" => "Energy Minerals",
+              "isActive" => true
+            }
+          ]
+        }.to_json
+      )
+
+      expect_request(response, "PETR4")
+
+      result = provider.lookup_asset(symbol: "PETR4")
+
+      expect(result).to eq(
+        MarketData::AssetData.new(
+          symbol: "PETR4",
+          name: "Petroleo Brasileiro SA Pfd",
+          currency: "BRL",
+          category: "stock",
+          subcategory: nil,
+          active: true
+        )
+      )
+    end
+
+    it "maps ETFs when BRAPI exposes the quote type" do
+      response = instance_double(
+        Net::HTTPOK,
+        code: "200",
+        body: {
+          "results" => [
+            {
+              "symbol" => "IVVB11",
+              "name" => "IVVB11",
+              "longName" => "iShares S&P 500 Fundo de Investimento em Cotas de Fundo de Indice - Investimento no Exterior",
+              "assetType" => "fund",
+              "subType" => "etf",
+              "exchange" => "B3",
+              "currency" => "BRL",
+              "sector" => "Miscellaneous",
+              "isActive" => true
+            }
+          ]
+        }.to_json
+      )
+
+      expect_request(response, "IVVB11")
+
+      result = provider.lookup_asset(symbol: "IVVB11")
+
+      expect(result.category).to eq("etf")
+    end
+  end
+
+  describe "#fetch_asset_metadata" do
+    it "raises not found when BRAPI returns no matching asset" do
+      response = instance_double(Net::HTTPOK, code: "200", body: { "results" => [] }.to_json)
+      expect_request(response, "UNKNOWN")
+
+      expect { provider.fetch_asset_metadata(symbol: "UNKNOWN") }
+        .to raise_error(MarketData::NotFoundError, "Asset not found for symbol UNKNOWN")
+    end
+
+    it "raises provider error when the response status is not successful" do
+      response = instance_double(Net::HTTPTooManyRequests, code: "429", body: "")
+      expect_request(response, "PETR4")
+
+      expect { provider.fetch_asset_metadata(symbol: "PETR4") }
+        .to raise_error(MarketData::ProviderError, "BRAPI request failed with status 429")
+    end
+
+    it "raises provider error when the payload contains a provider error" do
+      response = instance_double(
+        Net::HTTPOK,
+        code: "200",
+        body: { "error" => "Rate limit exceeded" }.to_json
+      )
+      expect_request(response, "PETR4")
+
+      expect { provider.fetch_asset_metadata(symbol: "PETR4") }
+        .to raise_error(MarketData::ProviderError, "Rate limit exceeded")
+    end
+  end
+
+  def expect_request(response, symbol)
+    allow(Net::HTTP).to receive(:start) do |hostname, port, use_ssl:, &block|
+      expect(hostname).to eq("brapi.dev")
+      expect(port).to eq(443)
+      expect(use_ssl).to be(true)
+
+      http = instance_double("Net::HTTP")
+      expect(http).to receive(:request) do |request|
+        expect(request.path).to include("/api/v2/tickers")
+        expect(request.path).to include("search=#{symbol}")
+        expect(request["Authorization"]).to eq("Bearer test-token")
+        response
+      end
+
+      block.call(http)
+    end
+  end
+end

--- a/spec/services/market_data/asset_lookup_service_spec.rb
+++ b/spec/services/market_data/asset_lookup_service_spec.rb
@@ -22,8 +22,23 @@ RSpec.describe MarketData::AssetLookupService do
     end
 
     it "uses the null provider by default" do
-      expect { described_class.new.call(symbol: "AAPL") }
-        .to raise_error(MarketData::ConfigurationError, "No market data provider configured")
+      provider = instance_double(MarketData::Providers::BrapiProvider)
+      allow(MarketData::Providers::BrapiProvider).to receive(:new).and_return(provider)
+      allow(provider).to receive(:lookup_asset).with(symbol: "AAPL").and_return(
+        MarketData::AssetData.new(
+          symbol: "AAPL",
+          name: "Apple Inc.",
+          currency: "USD",
+          category: "international",
+          subcategory: nil,
+          active: true
+        )
+      )
+
+      result = described_class.new.call(symbol: "AAPL")
+
+      expect(result.symbol).to eq("AAPL")
+      expect(provider).to have_received(:lookup_asset).with(symbol: "AAPL")
     end
   end
 end


### PR DESCRIPTION
## Summary
Replace the first market data provider implementation with a Brazil-first BRAPI integration and wire it into the MarketData lookup service.

## Motivation
Alpha Vantage proved too fragile for Brazilian asset lookup in practice. Since the product targets Brazil first, the initial provider should use a source that works naturally with B3 tickers and returns better metadata for asset creation.

## Main Changes
- replace the initial concrete provider with `MarketData::Providers::BrapiProvider`
- use BRAPI ticker search as the primary metadata source for asset lookup
- classify Brazilian stocks and ETFs from BRAPI metadata
- make `MarketData::AssetLookupService` use `BrapiProvider` by default
- add local `.env` loading support through `dotenv-rails`
- document the provider choice and register the implementation plan in governance docs
- add focused specs for BRAPI provider behavior and lookup service integration

## Impacts
- the first real market data integration is now Brazil-first
- lookup for `PETR4`, `VALE3`, and `IVVB11` works with real BRAPI responses
- no database or route changes were required

## Validation
- `bundle exec rspec spec/lib/market_data/provider_spec.rb spec/lib/market_data/null_provider_spec.rb spec/lib/market_data/providers/brapi_provider_spec.rb spec/services/market_data/asset_lookup_service_spec.rb`
- result: `13 examples, 0 failures`
- real lookup checks passed for `PETR4`, `VALE3`, and `IVVB11` using the configured BRAPI token

## Notes
- the existing ViewComponent deprecation warning for Ruby versions lower than 3.2 still appears during runs and was not introduced by this change.
