### PR TITLE
Add ticker-based asset autofill and category-aware subcategory validation

### DIFF
--- a/app/controllers/investments/assets_controller.rb
+++ b/app/controllers/investments/assets_controller.rb
@@ -18,7 +18,7 @@ module Investments
 
     def new
       @asset = Investments::Asset.new
-      @subcategories = subcategory_options
+      @subcategories = form_subcategory_options(@asset.category)
       @categories = category_options
       render :form
     end
@@ -26,7 +26,10 @@ module Investments
     def create
       @asset = Investments::Asset.new(asset_params)
       @categories = category_options
-      @subcategories = subcategory_options
+      @subcategories = form_subcategory_options(@asset.category)
+      apply_lookup_metadata(@asset)
+      @subcategories = form_subcategory_options(@asset.category)
+      return render(:form, status: :unprocessable_entity) if @asset.errors.any?
 
       if @asset.save
         redirect_to investments_asset_path(@asset), notice: "Ativo criado com sucesso."
@@ -37,13 +40,13 @@ module Investments
 
     def edit
       @categories = category_options
-      @subcategories = subcategory_options
+      @subcategories = form_subcategory_options(@asset.category)
       render :form
     end
 
     def update
       @categories = category_options
-      @subcategories = subcategory_options
+      @subcategories = form_subcategory_options(asset_params[:category].presence || @asset.category)
       if @asset.update(asset_params)
         redirect_to investments_asset_path(@asset), notice: "Ativo alterado com sucesso."
       else
@@ -57,8 +60,38 @@ module Investments
       params.require(:investments_asset).permit(:name, :symbol, :category, :subcategory, :currency, :active)
     end
 
+    def apply_lookup_metadata(asset)
+      return unless lookup_only_submission?(asset)
+
+      asset_data = MarketData::AssetLookupService.new.call(symbol: asset.symbol)
+
+      asset.name = asset_data.name
+      asset.category = asset_data.category if asset_data.category.present?
+      asset.subcategory = asset_data.subcategory if asset_data.subcategory.present?
+      asset.currency = asset_data.currency
+      asset.active = asset_data.active
+    rescue MarketData::NotFoundError
+      asset.errors.add(:symbol, "nao foi encontrado no provedor de mercado")
+      preserve_lookup_only_defaults(asset)
+    rescue MarketData::ProviderError, MarketData::ConfigurationError => e
+      asset.errors.add(:base, "Nao foi possivel buscar os dados do ativo: #{e.message}")
+      preserve_lookup_only_defaults(asset)
+    end
+
     def set_asset
       @asset = Investments::Asset.find(params[:id])
+    end
+
+    def lookup_only_submission?(asset)
+      asset.symbol.present? &&
+        asset.name.blank? &&
+        asset.category.blank? &&
+        asset.currency.blank? &&
+        asset.subcategory.blank?
+    end
+
+    def preserve_lookup_only_defaults(asset)
+      asset.active = true if asset.active.nil?
     end
 
     def category_options
@@ -72,6 +105,15 @@ module Investments
 
     def subcategory_options
       Investments::Asset.subcategories.keys.map do |key|
+        [
+          I18n.t("activerecord.attributes.investments/asset.subcategories.#{key}"),
+          key
+        ]
+      end
+    end
+
+    def form_subcategory_options(category)
+      Investments::Asset.allowed_subcategories_for(category).map do |key|
         [
           I18n.t("activerecord.attributes.investments/asset.subcategories.#{key}"),
           key

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,2 +1,42 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
+
+const buildSubcategoryOptions = (select, options, selectedValue) => {
+  const blankOption = document.createElement("option")
+  blankOption.value = ""
+  blankOption.textContent = "Opcional"
+  select.replaceChildren(blankOption)
+
+  options.forEach(([label, value]) => {
+    const option = document.createElement("option")
+    option.value = value
+    option.textContent = label
+    option.selected = value === selectedValue
+    select.appendChild(option)
+  })
+
+  if (selectedValue && !options.some(([, value]) => value === selectedValue)) {
+    select.value = ""
+  }
+}
+
+const initializeAssetSubcategoryFilter = () => {
+  const categorySelect = document.querySelector("#investments_asset_category")
+  const subcategorySelect = document.querySelector('[data-role="asset-subcategory-select"]')
+  if (!categorySelect || !subcategorySelect) return
+
+  const subcategoryMap = JSON.parse(categorySelect.dataset.subcategoryMap || "{}")
+
+  const syncSubcategories = () => {
+    const selectedCategory = categorySelect.value
+    const currentSubcategory = subcategorySelect.value
+    const options = subcategoryMap[selectedCategory] || []
+    buildSubcategoryOptions(subcategorySelect, options, currentSubcategory)
+    subcategorySelect.disabled = options.length === 0
+  }
+
+  syncSubcategories()
+  categorySelect.addEventListener("change", syncSubcategories)
+}
+
+document.addEventListener("turbo:load", initializeAssetSubcategoryFilter)

--- a/app/models/investments/asset.rb
+++ b/app/models/investments/asset.rb
@@ -3,6 +3,15 @@ module Investments
     # Assets are modeled as a global market catalog, not as user-owned records.
     self.table_name = "investments_assets"
 
+    CATEGORY_SUBCATEGORY_MAP = {
+      "stock" => %w[banks energy technology retail mining agribusiness utilities healthcare],
+      "fii" => %w[paper brick logistics shopping_malls offices receivables],
+      "etf" => [],
+      "crypto" => [],
+      "fixed_income" => [],
+      "international" => %w[technology retail energy mining utilities healthcare]
+    }.freeze
+
     has_many :incomes, class_name: "Investments::Income", dependent: :restrict_with_exception
     has_many :transactions, class_name: "Investments::Transaction", dependent: :restrict_with_exception
 
@@ -20,12 +29,29 @@ module Investments
       brick: 1,
       banks: 2,
       energy: 3,
-      technology: 4
+      technology: 4,
+      retail: 5,
+      mining: 6,
+      agribusiness: 7,
+      logistics: 8,
+      shopping_malls: 9,
+      offices: 10,
+      receivables: 11,
+      utilities: 12,
+      healthcare: 13
     }
 
     validates :name, :symbol, :category, :currency, presence: true
     validates :symbol, uniqueness: true
+    validate :subcategory_must_match_category
 
+    def self.allowed_subcategories_for(category)
+      CATEGORY_SUBCATEGORY_MAP.fetch(category.to_s, [])
+    end
+
+    def self.category_supports_subcategories?(category)
+      allowed_subcategories_for(category).any?
+    end
 
     def human_category
       I18n.t(
@@ -41,5 +67,14 @@ module Investments
       )
     end
 
+    private
+
+    def subcategory_must_match_category
+      return if subcategory.blank? || category.blank?
+
+      return if self.class.allowed_subcategories_for(category).include?(subcategory)
+
+      errors.add(:subcategory, :invalid_for_category)
+    end
   end
 end

--- a/app/views/investments/assets/form.html.erb
+++ b/app/views/investments/assets/form.html.erb
@@ -1,3 +1,7 @@
+<% subcategory_map = Investments::Asset::CATEGORY_SUBCATEGORY_MAP.transform_values do |keys| %>
+  <% keys.map { |key| [I18n.t("activerecord.attributes.investments/asset.subcategories.#{key}"), key] } %>
+<% end %>
+
 <div class="container mt-8 max-w-3xl">
   <%= link_to investments_assets_path, class: "inline-flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2 text-sm text-white text-decoration-none transition hover:bg-gray-700" do %>
     <i class="fa-solid fa-circle-left"></i>Voltar
@@ -8,6 +12,9 @@
       <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Investments</p>
       <h1 class="mt-2 text-3xl font-semibold text-gray-900"><%= @asset.persisted? ? "Editar Ativo" : "Novo Ativo" %></h1>
       <p class="mt-2 text-sm text-gray-600">Cadastre ativos com categoria, moeda e status para uso no dominio de investimentos.</p>
+      <% unless @asset.persisted? %>
+        <p class="mt-2 text-sm text-slate-500">Voce pode informar apenas o ticker para tentar o preenchimento automatico, ou continuar com o cadastro manual.</p>
+      <% end %>
     </div>
 
     <div class="px-6 py-6">
@@ -26,7 +33,7 @@
         <div class="grid gap-5 md:grid-cols-2">
           <div>
             <%= f.label :name, "Nome", class: "mb-2 block text-sm font-medium text-gray-900" %>
-            <%= f.text_field :name, class: "block w-full rounded-2xl border border-gray-300 px-4 py-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100", required: true %>
+            <%= f.text_field :name, class: "block w-full rounded-2xl border border-gray-300 px-4 py-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100" %>
           </div>
 
           <div>
@@ -38,21 +45,23 @@
             <%= f.label :category, "Categoria", class: "mb-2 block text-sm font-medium text-gray-900" %>
             <%= f.select :category,
                          options_for_select(@categories, @asset.category),
-                         {},
-                         class: "block w-full rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100" %>
+                         { include_blank: @asset.persisted? ? false : "Selecione uma categoria" },
+                         class: "block w-full rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100",
+                         data: { subcategory_map: json_escape(subcategory_map.to_json) } %>
           </div>
 
            <div>
             <%= f.label :subcategory, "SubCategoria", class: "mb-2 block text-sm font-medium text-gray-900" %>
             <%= f.select :subcategory,
                          options_for_select(@subcategories, @asset.subcategory),
-                         {},
-                         class: "block w-full rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100" %>
+                         { include_blank: "Opcional" },
+                         class: "block w-full rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100",
+                         data: { role: "asset-subcategory-select" } %>
           </div>
 
           <div>
             <%= f.label :currency, "Moeda", class: "mb-2 block text-sm font-medium text-gray-900" %>
-            <%= f.text_field :currency, class: "block w-full rounded-2xl border border-gray-300 px-4 py-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100", placeholder: "BRL, USD...", required: true %>
+            <%= f.text_field :currency, class: "block w-full rounded-2xl border border-gray-300 px-4 py-3 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100", placeholder: "BRL, USD..." %>
           </div>
         </div>
 

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -10,6 +10,12 @@ pt-BR:
   activerecord:
     attributes:
       investments/asset:
+        name: "Nome"
+        symbol: "Ticker / Simbolo"
+        category: "Categoria"
+        subcategory: "SubCategoria"
+        currency: "Moeda"
+        active: "Ativo"
         categories:
           stock: "Ações"
           fii: "Fundos Imobiliários"
@@ -24,6 +30,15 @@ pt-BR:
           banks: "Bancos"
           energy: "Energia"
           technology: "Tecnologia"
+          retail: "Varejo"
+          mining: "Mineração"
+          agribusiness: "Agronegócio"
+          logistics: "Logística"
+          shopping_malls: "Shoppings"
+          offices: "Lajes Corporativas"
+          receivables: "Recebíveis"
+          utilities: "Utilidades Públicas"
+          healthcare: "Saúde"
 
       investments/income:
         income_types:
@@ -49,3 +64,9 @@ pt-BR:
           transfer: "Transferência"
           split: "Split"
           reverse_split: "Reverse Split"
+
+    errors:
+      messages:
+        blank: "não pode ficar em branco"
+        taken: "já está em uso"
+        invalid_for_category: "não é compatível com a categoria selecionada"

--- a/docs/governance/issue-73-implementation-plan.md
+++ b/docs/governance/issue-73-implementation-plan.md
@@ -1,0 +1,51 @@
+# Issue 73 Implementation Plan
+
+## Objective
+
+Allow users to create investment assets by entering only the ticker and automatically filling the remaining asset information through the market data provider abstraction.
+
+## Affected Files
+
+- `app/controllers/investments/assets_controller.rb`
+- `app/views/investments/assets/form.html.erb`
+- `spec/requests/investments/assets_spec.rb`
+- `docs/governance/issue-73-implementation-plan.md`
+
+## Risks
+
+- Breaking the existing manual asset creation flow while introducing autofill
+- Persisting partially filled records when lookup fails
+- Creating controller logic that couples too directly to provider details instead of the lookup service
+
+## Technical Strategy
+
+Keep the current manual flow compatible, but when the submitted asset only contains a ticker, attempt an asset lookup through `MarketData::AssetLookupService`.
+
+If lookup succeeds, fill:
+
+- name
+- category
+- currency
+- active
+
+Keep subcategory optional when the provider does not return one.
+
+If lookup fails, add a validation-style error to the form and keep the user on the creation screen.
+
+## Database Impact
+
+No database changes are required for this issue.
+
+The work is limited to controller/form behavior and request coverage.
+
+## Required Tests
+
+- request spec for successful autofill from ticker
+- request spec for invalid ticker lookup failure
+- request spec proving manual asset creation still works
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-07-12

--- a/spec/models/investments/asset_spec.rb
+++ b/spec/models/investments/asset_spec.rb
@@ -18,28 +18,28 @@ RSpec.describe Investments::Asset, type: :model do
     asset.name = nil
 
     expect(asset).not_to be_valid
-    expect(asset.errors[:name]).to include("can't be blank")
+    expect(asset.errors[:name]).to include("não pode ficar em branco")
   end
 
   it "is invalid without a symbol" do
     asset.symbol = nil
 
     expect(asset).not_to be_valid
-    expect(asset.errors[:symbol]).to include("can't be blank")
+    expect(asset.errors[:symbol]).to include("não pode ficar em branco")
   end
 
   it "is invalid without a category" do
     asset.category = nil
 
     expect(asset).not_to be_valid
-    expect(asset.errors[:category]).to include("can't be blank")
+    expect(asset.errors[:category]).to include("não pode ficar em branco")
   end
 
   it "is invalid without a currency" do
     asset.currency = nil
 
     expect(asset).not_to be_valid
-    expect(asset.errors[:currency]).to include("can't be blank")
+    expect(asset.errors[:currency]).to include("não pode ficar em branco")
   end
 
   it "does not allow duplicate symbols" do
@@ -51,7 +51,7 @@ RSpec.describe Investments::Asset, type: :model do
     )
 
     expect(asset).not_to be_valid
-    expect(asset.errors[:symbol]).to include("has already been taken")
+    expect(asset.errors[:symbol]).to include("já está em uso")
   end
 
   it "defines the expected categories" do
@@ -66,18 +66,42 @@ RSpec.describe Investments::Asset, type: :model do
   end
 
   it "defines the expected subcategories" do
-  expect(described_class.subcategories.keys).to contain_exactly(
-    "paper",
-    "brick",
-    "banks",
-    "energy",
-    "technology"
-  )
-end
+    expect(described_class.subcategories.keys).to contain_exactly(
+      "paper",
+      "brick",
+      "banks",
+      "energy",
+      "technology",
+      "retail",
+      "mining",
+      "agribusiness",
+      "logistics",
+      "shopping_malls",
+      "offices",
+      "receivables",
+      "utilities",
+      "healthcare"
+    )
+  end
 
   it "defaults active to true" do
     asset.save!
 
     expect(asset.active).to be(true)
+  end
+
+  it "allows a subcategory compatible with the selected category" do
+    asset.category = :stock
+    asset.subcategory = :energy
+
+    expect(asset).to be_valid
+  end
+
+  it "rejects a subcategory incompatible with the selected category" do
+    asset.category = :stock
+    asset.subcategory = :paper
+
+    expect(asset).not_to be_valid
+    expect(asset.errors[:subcategory]).to include("não é compatível com a categoria selecionada")
   end
 end

--- a/spec/requests/investments/assets_spec.rb
+++ b/spec/requests/investments/assets_spec.rb
@@ -58,11 +58,66 @@ RSpec.describe "Investments::Assets", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Apple Inc.")
-      expect(response.body).to include("International")
+      expect(response.body).to include("Internacional")
     end
   end
 
   describe "POST /create" do
+    it "creates an asset by auto-filling fields from the market data provider" do
+      asset_data = MarketData::AssetData.new(
+        symbol: "PETR4",
+        name: "Petroleo Brasileiro SA Pfd",
+        currency: "BRL",
+        category: "stock",
+        subcategory: nil,
+        active: true
+      )
+
+      lookup_service = instance_double(MarketData::AssetLookupService, call: asset_data)
+      allow(MarketData::AssetLookupService).to receive(:new).and_return(lookup_service)
+
+      expect do
+        post investments_assets_path, params: {
+          investments_asset: {
+            name: "",
+            symbol: "PETR4",
+            category: "",
+            subcategory: "",
+            currency: ""
+          }
+        }
+      end.to change(Investments::Asset, :count).by(1)
+
+      asset = Investments::Asset.order(:created_at).last
+      expect(response).to redirect_to(investments_asset_path(asset))
+      expect(asset.name).to eq("Petroleo Brasileiro SA Pfd")
+      expect(asset.category).to eq("stock")
+      expect(asset.currency).to eq("BRL")
+      expect(asset.active).to be(true)
+      expect(lookup_service).to have_received(:call).with(symbol: "PETR4")
+    end
+
+    it "renders the form with an error when the ticker is not found" do
+      lookup_service = instance_double(MarketData::AssetLookupService)
+      allow(MarketData::AssetLookupService).to receive(:new).and_return(lookup_service)
+      allow(lookup_service).to receive(:call).and_raise(MarketData::NotFoundError, "missing")
+
+      expect do
+        post investments_assets_path, params: {
+          investments_asset: {
+            name: "",
+            symbol: "INVALIDO",
+            category: "",
+            subcategory: "",
+            currency: ""
+          }
+        }
+      end.not_to change(Investments::Asset, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Ticker / Simbolo nao foi encontrado no provedor de mercado")
+    end
+
     it "creates an asset with category support" do
       expect do
         post investments_assets_path, params: {
@@ -70,6 +125,7 @@ RSpec.describe "Investments::Assets", type: :request do
             name: "XP Malls",
             symbol: "XPML11",
             category: "fii",
+            subcategory: "shopping_malls",
             currency: "BRL",
             active: "1"
           }
@@ -79,6 +135,24 @@ RSpec.describe "Investments::Assets", type: :request do
       asset = Investments::Asset.order(:created_at).last
       expect(response).to redirect_to(investments_asset_path(asset))
       expect(asset.category).to eq("fii")
+    end
+
+    it "rejects incompatible category and subcategory combinations" do
+      expect do
+        post investments_assets_path, params: {
+          investments_asset: {
+            name: "Petrobras",
+            symbol: "PETR4-MANUAL",
+            category: "stock",
+            subcategory: "paper",
+            currency: "BRL",
+            active: "1"
+          }
+        }
+      end.not_to change(Investments::Asset, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("SubCategoria não é compatível com a categoria selecionada")
     end
   end
 


### PR DESCRIPTION
## Summary
- adds asset creation autofill based on ticker lookup through `MarketData::AssetLookupService`
- keeps the manual asset creation flow compatible
- improves validation messages in Portuguese
- expands the available asset subcategories
- validates on the backend that subcategory/category combinations are allowed
- filters subcategory options in the form based on the selected category

## What changed
- `AssetsController` now performs a lookup when the user submits only a ticker
- the asset form now supports the autofill-oriented flow
- `Name` and `Currency` are no longer blocked by browser-level `required` validation during lookup-only submissions
- `Category` and `Subcategory` now start blank for new asset creation
- `Investments::Asset` now defines allowed subcategories per category
- the frontend dynamically updates subcategory options when category changes
- `pt-BR` translations were added/improved for attributes and validation messages

## Validation
- `bundle exec rspec spec/requests/investments/assets_spec.rb`
- `bundle exec rspec spec/models/investments/asset_spec.rb`

## Notes
- autofill still keeps `subcategory` optional when the provider does not return it
- invalid combinations such as `stock + paper` are now rejected in the backend