### PR TITLE
Add portfolio dashboard filters

### DIFF
--- a/app/controllers/investments/portfolios_controller.rb
+++ b/app/controllers/investments/portfolios_controller.rb
@@ -1,5 +1,12 @@
 module Investments
   class PortfoliosController < ApplicationController
+    DashboardFilters = Struct.new(
+      :from_date,
+      :to_date,
+      :category,
+      keyword_init: true
+    )
+
     before_action :set_portfolio, only: %i[show edit update destroy]
 
     def index
@@ -7,7 +14,14 @@ module Investments
     end
 
     def show
-      @dashboard = Investments::PortfolioDashboardBuilder.call(portfolio: @portfolio)
+      @dashboard_filters = build_dashboard_filters
+      @category_options = dashboard_category_options
+      @dashboard = Investments::PortfolioDashboardBuilder.call(
+        portfolio: @portfolio,
+        from_date: @dashboard_filters.from_date,
+        to_date: @dashboard_filters.to_date,
+        category: @dashboard_filters.category
+      )
     end
 
     def new
@@ -52,6 +66,38 @@ module Investments
     def set_portfolio
       # User-owned portfolios must always be resolved through the authenticated user.
       @portfolio = current_user.investment_portfolios.find(params[:id])
+    end
+
+    def build_dashboard_filters
+      DashboardFilters.new(
+        from_date: parse_filter_date(params[:from_date]),
+        to_date: parse_filter_date(params[:to_date]),
+        category: permitted_category(params[:category])
+      )
+    end
+
+    def parse_filter_date(value)
+      return if value.blank?
+
+      Date.iso8601(value)
+    rescue ArgumentError
+      nil
+    end
+
+    def permitted_category(value)
+      return if value.blank?
+      return value if Investments::Asset.categories.key?(value)
+
+      nil
+    end
+
+    def dashboard_category_options
+      Investments::Asset.categories.keys.map do |key|
+        [
+          I18n.t("activerecord.attributes.investments/asset.categories.#{key}"),
+          key
+        ]
+      end
     end
   end
 end

--- a/app/services/investments/portfolio_dashboard_builder.rb
+++ b/app/services/investments/portfolio_dashboard_builder.rb
@@ -55,13 +55,34 @@ module Investments
 
     ZERO = BigDecimal("0")
 
-    def initialize(portfolio:, price_lookup_service: MarketData::PriceLookupService.new)
+    def initialize(
+      portfolio:,
+      price_lookup_service: MarketData::PriceLookupService.new,
+      from_date: nil,
+      to_date: nil,
+      category: nil
+    )
       @portfolio = portfolio
       @price_lookup_service = price_lookup_service
+      @from_date = from_date
+      @to_date = to_date
+      @category = category
     end
 
-    def self.call(portfolio:, price_lookup_service: MarketData::PriceLookupService.new)
-      new(portfolio: portfolio, price_lookup_service: price_lookup_service).call
+    def self.call(
+      portfolio:,
+      price_lookup_service: MarketData::PriceLookupService.new,
+      from_date: nil,
+      to_date: nil,
+      category: nil
+    )
+      new(
+        portfolio: portfolio,
+        price_lookup_service: price_lookup_service,
+        from_date: from_date,
+        to_date: to_date,
+        category: category
+      ).call
     end
 
     # Builds the full dashboard snapshot, keeping transaction history separate from market-price valuation.
@@ -104,18 +125,27 @@ module Investments
 
     private
 
-    attr_reader :portfolio, :price_lookup_service
+    attr_reader :portfolio, :price_lookup_service, :from_date, :to_date, :category
 
     def transactions
-      portfolio
+      scope = portfolio
         .transactions
         .includes(:asset)
         .where(transaction_type: [:buy, :sell])
-        .order(:date, :id)
+      scope = scope.where(date: from_date..) if from_date.present?
+      scope = scope.where(date: ..to_date) if to_date.present?
+      scope = scope.joins(:asset).where(investments_assets: { category: Investments::Asset.categories[category] }) if category.present?
+      scope.order(:date, :id)
     end
 
     def incomes
-      @incomes ||= portfolio.incomes.to_a
+      @incomes ||= begin
+        scope = portfolio.incomes.includes(:asset)
+        scope = scope.where(payment_date: from_date..) if from_date.present?
+        scope = scope.where(payment_date: ..to_date) if to_date.present?
+        scope = scope.joins(:asset).where(investments_assets: { category: Investments::Asset.categories[category] }) if category.present?
+        scope.to_a
+      end
     end
 
     # Reconstructs the current open position for one asset from its buy and sell history.

--- a/app/views/investments/portfolios/show.html.erb
+++ b/app/views/investments/portfolios/show.html.erb
@@ -1,8 +1,8 @@
-<div class="container max-w-7xl">
+<div class="mx-auto w-full max-w-7xl">
 
   <div class="mt-6 overflow-hidden rounded-3xl border border-gray-400 bg-white shadow-sm">
-    <div class="border-b border-gray-100 bg-gradient-to-r from-slate-50 to-white px-6 py-5 lg:px-8 lg:py-5.5">
-      <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div class="border-b border-gray-100 bg-gradient-to-r from-slate-50 to-white px-6 py-4 lg:px-8 ">
+      <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Portfolio Dashboard</p>
           <div class="mt-1">
@@ -13,28 +13,59 @@
             <% end %>
           </div>
           <h1 class="mt-3 text-3xl font-semibold text-gray-900"><%= @portfolio.name %></h1>
-          <div class="mt-3 flex flex-wrap items-center gap-3 text-sm text-gray-500">
-            <%= link_to investments_transactions_path,
-              class: "inline-flex items-center gap-2 rounded-full bg-green-700 px-4 py-2 text-sm text-white text-decoration-none transition hover:bg-gray-700" do %>
-              <i class="fa-solid fa-circle-right"></i>Ver transações
-            <% end %>
-            <p>Criado em <%= l(@portfolio.created_at.to_date) %></p>
-          </div>
         </div>
 
-        <% if @dashboard.market_value_approximation %>
-          <div class="rounded-2xl border border-amber-500 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-800 lg:max-w-sm">
-            Valor atual usa cotacao de mercado quando disponivel. Ativos sem cotacao seguem com custo medio como aproximacao.
-          </div>
-        <% else %>
-          <div class="rounded-2xl border border-emerald-500 bg-emerald-50 px-4 py-3 text-sm leading-6 text-emerald-800 lg:max-w-sm">
-            Valor atual e lucro/prejuizo estao baseados nas cotacoes de mercado mais recentes disponiveis.
-          </div>
-        <% end %>
+        <div class="flex flex-col items-start gap-3 lg:items-end">
+          <% if @dashboard.market_value_approximation %>
+            <div class="rounded-2xl border border-amber-500 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-800 lg:max-w-sm">
+              Valor atual com fallback por custo para ativos sem cotacao.
+            </div>
+          <% else %>
+            <div class="rounded-2xl border border-emerald-500 bg-emerald-50 px-4 py-3 text-sm leading-6 text-emerald-800 lg:max-w-sm">
+              Valor atual baseado nas cotacoes mais recentes.
+            </div>
+          <% end %>
+
+          <%= link_to investments_transactions_path,
+            class: "inline-flex items-center gap-2 rounded-full bg-green-700 px-4 py-2 text-sm text-white text-decoration-none transition hover:bg-gray-700" do %>
+            <i class="fa-solid fa-circle-right"></i>Ver transações
+          <% end %>
+        </div>
       </div>
     </div>
 
-    <div class="px-6 py-6 lg:px-8 lg:py-8">
+    <div class="px-4 py-4 lg:px-8 ">
+      <div class="rounded-2xl border border-gray-400 bg-white px-5 py-4 lg:px-6 lg:py-4.5 mb-6">
+        <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+
+
+          <%= form_with url: investments_portfolio_path(@portfolio), method: :get, local: true, class: "grid w-full gap-3 md:grid-cols-2 xl:grid-cols-[0.9fr_0.9fr_0.9fr_auto]" do |f| %>
+            <div>
+              <%= f.label :from_date, "Data inicial", class: "mb-1.5 block text-sm font-medium text-gray-900" %>
+              <%= f.date_field :from_date, value: @dashboard_filters.from_date, class: "block w-full rounded-2xl border border-gray-300 px-4 py-2.5 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100" %>
+            </div>
+
+            <div>
+              <%= f.label :to_date, "Data final", class: "mb-1.5 block text-sm font-medium text-gray-900" %>
+              <%= f.date_field :to_date, value: @dashboard_filters.to_date, class: "block w-full rounded-2xl border border-gray-300 px-4 py-2.5 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100" %>
+            </div>
+
+            <div>
+              <%= f.label :category, "Categoria", class: "mb-1.5 block text-sm font-medium text-gray-900" %>
+              <%= f.select :category,
+                           options_for_select([["Todas", ""]] + @category_options, @dashboard_filters.category),
+                           {},
+                           class: "block w-full rounded-2xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 shadow-sm outline-none transition focus:border-blue-500 focus:ring-4 focus:ring-blue-100" %>
+            </div>
+
+            <div class="flex flex-wrap items-end gap-3 xl:justify-end">
+              <%= f.submit "Aplicar", class: "rounded-full bg-blue-700 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-blue-800 focus:outline-none focus:ring-4 focus:ring-blue-300" %>
+              <%= link_to "Limpar", investments_portfolio_path(@portfolio), class: "rounded-full border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
       <div class="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
         <div class="rounded-2xl border border-gray-400 bg-slate-50 p-5">
           <p class="text-sm text-gray-500">Total investido</p>
@@ -106,9 +137,9 @@
                   <tr>
                     <th class="py-3.5 pr-6 font-medium">Ativo</th>
                     <th class="py-3.5 pr-6 font-medium">Quantidade</th>
+                    <th class="py-3.5 pr-6 font-medium">Preco atual</th>
                     <th class="py-3.5 pr-6 font-medium">Preco medio</th>
                     <th class="py-3.5 pr-6 font-medium">Investido</th>
-                    <th class="py-3.5 pr-6 font-medium">Preco atual</th>
                     <th class="py-3.5 pr-6 font-medium">Valor atual</th>
                     <th class="py-3.5 font-medium">Alocacao</th>
                   </tr>
@@ -121,23 +152,31 @@
                         <div class="mt-1 text-xs text-gray-500"><%= entry.asset.name %></div>
                       </td>
                       <td class="py-4 pr-6 text-gray-700"><%= number_with_precision(entry.quantity, precision: 8, strip_insignificant_zeros: true) %></td>
-                      <td class="py-4 pr-6 text-gray-700"><%= number_to_currency(entry.average_price, unit: "R$ ", separator: ",", delimiter: ".") %></td>
-                      <td class="py-4 pr-6 text-gray-700"><%= number_to_currency(entry.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %></td>
                       <td class="py-4 pr-6 text-gray-700">
                         <% if entry.price_source == :market %>
-                          <div><%= number_to_currency(entry.market_price, unit: "R$ ", separator: ",", delimiter: ".") %></div>
-                          <div class="mt-1 text-xs text-emerald-700">Cotacao de mercado</div>
+                          <% price_tone_class =
+                            if entry.market_price > entry.average_price
+                              "text-emerald-600"
+                            elsif entry.market_price < entry.average_price
+                              "text-rose-600"
+                            else
+                              "text-gray-700"
+                            end
+                          %>
+                          <div class="<%= price_tone_class %> font-medium">
+                            <%= entry.market_price > entry.average_price ? "↑" : entry.market_price < entry.average_price ? "↓" : "" %>
+                            <%= number_to_currency(entry.market_price, unit: "R$ ", separator: ",", delimiter: ".") %>
+                            </div>
                         <% else %>
                           <div>-</div>
                           <div class="mt-1 text-xs text-amber-700">Sem cotacao</div>
                         <% end %>
                       </td>
+                      <td class="py-4 pr-6 text-gray-700"><%= number_to_currency(entry.average_price, unit: "R$ ", separator: ",", delimiter: ".") %></td>
+                      <td class="py-4 pr-6 text-gray-700"><%= number_to_currency(entry.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %></td>
                       <td class="py-4 pr-6 text-gray-700"><%= number_to_currency(entry.current_value, unit: "R$ ", separator: ",", delimiter: ".") %></td>
                       <td class="py-4">
                         <div class="flex items-center gap-3">
-                          <div class="h-2 w-full max-w-28 overflow-hidden rounded-full bg-gray-100">
-                            <div class="h-full rounded-full bg-blue-600" style="width: <%= [entry.allocation_percentage.to_f.round(2), 100].min %>%"></div>
-                          </div>
                           <span class="min-w-16 text-gray-700"><%= number_with_precision(entry.allocation_percentage, precision: 2) %>%</span>
                         </div>
                       </td>
@@ -227,90 +266,84 @@
               </ul>
             </div>
           <% end %>
-
-          <div class="mt-8 flex flex-wrap gap-3">
-            <%= link_to edit_investments_portfolio_path(@portfolio) do %>
-              <%= render ButtonComponent.new(label: "Edit") %>
-            <% end %>
-
-            <%= link_to investments_portfolio_path(@portfolio), data: { turbo_method: :delete, turbo_confirm: "Tem certeza que deseja apagar este portfolio?" } do %>
-              <%= render ButtonComponent.new(label: "Apagar") %>
-            <% end %>
-          </div>
         </div>
       </div>
 
       <div class="mt-6 grid gap-4 xl:grid-cols-2">
         <div class="rounded-2xl border border-gray-400 bg-white p-4 lg:p-5">
-          <div class="flex items-center justify-between">
-            <h2 class="text-lg font-semibold text-gray-900">Alocacao por categoria</h2>
-            <span class="text-sm text-gray-500"><%= @dashboard.category_allocations.count %> categorias</span>
-          </div>
+          <details>
+            <summary class="flex cursor-pointer list-none items-center justify-between gap-4">
+              <h2 class="text-lg font-semibold text-gray-900">Alocacao por categoria</h2>
+              <span class="text-sm text-gray-500"><%= @dashboard.category_allocations.count %> categorias</span>
+            </summary>
 
-          <% if @dashboard.category_allocations.any? %>
-            <div class="mt-4 space-y-2.5">
-              <% @dashboard.category_allocations.each do |allocation| %>
-                <div class="rounded-xl border border-gray-100 bg-slate-50 px-3 py-2.5">
-                  <div class="flex items-center justify-between gap-4">
-                    <div>
-                      <p class="font-medium text-gray-900"><%= allocation.label %></p>
-                      <p class="text-sm text-gray-500">
-                        <%= number_to_currency(allocation.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %>
-                      </p>
+            <% if @dashboard.category_allocations.any? %>
+              <div class="mt-4 space-y-2.5">
+                <% @dashboard.category_allocations.each do |allocation| %>
+                  <div class="rounded-xl border border-gray-100 bg-slate-50 px-3 py-2.5">
+                    <div class="flex items-center justify-between gap-4">
+                      <div>
+                        <p class="font-medium text-gray-900"><%= allocation.label %></p>
+                        <p class="text-sm text-gray-500">
+                          <%= number_to_currency(allocation.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %>
+                        </p>
+                      </div>
+
+                      <span class="text-sm font-medium text-gray-700">
+                        <%= number_with_precision(allocation.allocation_percentage, precision: 2) %>%
+                      </span>
                     </div>
 
-                    <span class="text-sm font-medium text-gray-700">
-                      <%= number_with_precision(allocation.allocation_percentage, precision: 2) %>%
-                    </span>
+                    <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
+                      <div class="h-full rounded-full bg-emerald-600" style="width: <%= [allocation.allocation_percentage.to_f.round(2), 100].min %>%"></div>
+                    </div>
                   </div>
-
-                  <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
-                    <div class="h-full rounded-full bg-emerald-600" style="width: <%= [allocation.allocation_percentage.to_f.round(2), 100].min %>%"></div>
-                  </div>
-                </div>
-              <% end %>
-            </div>
-          <% else %>
-            <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-gray-600">
-              Nenhuma alocacao por categoria disponivel para este portfolio.
-            </div>
-          <% end %>
+                <% end %>
+              </div>
+            <% else %>
+              <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-gray-600">
+                Nenhuma alocacao por categoria disponivel para este portfolio.
+              </div>
+            <% end %>
+          </details>
         </div>
 
         <div class="rounded-2xl border border-gray-400 bg-white p-4 lg:p-5">
-          <div class="flex items-center justify-between">
-            <h2 class="text-lg font-semibold text-gray-900">Alocacao por subcategoria</h2>
-            <span class="text-sm text-gray-500"><%= @dashboard.subcategory_allocations.count %> grupos</span>
-          </div>
+          <details>
+            <summary class="flex cursor-pointer list-none items-center justify-between gap-4">
+              <h2 class="text-lg font-semibold text-gray-900">Alocacao por subcategoria</h2>
+              <span class="text-sm text-gray-500"><%= @dashboard.subcategory_allocations.count %> grupos</span>
+            </summary>
 
-          <% if @dashboard.subcategory_allocations.any? %>
-            <div class="mt-4 space-y-2.5">
-              <% @dashboard.subcategory_allocations.each do |allocation| %>
-                <div class="rounded-xl border border-gray-100 bg-slate-50 px-3 py-2.5">
-                  <div class="flex items-center justify-between gap-4">
-                    <div>
-                      <p class="font-medium text-gray-900"><%= allocation.label %></p>
-                      <p class="text-sm text-gray-500">
-                        <%= number_to_currency(allocation.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %>
-                      </p>
+            <% if @dashboard.subcategory_allocations.any? %>
+              <div class="mt-4 space-y-2.5">
+                <% @dashboard.subcategory_allocations.each do |allocation| %>
+                  <div class="rounded-xl border border-gray-100 bg-slate-50 px-3 py-2.5">
+                    <div class="flex items-center justify-between gap-4">
+                      <div>
+                        <p class="font-medium text-gray-900"><%= allocation.label %></p>
+                        <p class="text-sm text-gray-500">
+                          <%= number_to_currency(allocation.invested_amount, unit: "R$ ", separator: ",", delimiter: ".") %>
+                        </p>
+                      </div>
+
+                      <span class="text-sm font-medium text-gray-700">
+                        <%= number_with_precision(allocation.allocation_percentage, precision: 2) %>%
+                      </span>
                     </div>
 
-                    <span class="text-sm font-medium text-gray-700">
-                      <%= number_with_precision(allocation.allocation_percentage, precision: 2) %>%
-                    </span>
+                    <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
+                      <div class="h-full rounded-full bg-cyan-600" style="width: <%= [allocation.allocation_percentage.to_f.round(2), 100].min %>%"></div>
+                    </div>
                   </div>
-
-                  <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
-                    <div class="h-full rounded-full bg-cyan-600" style="width: <%= [allocation.allocation_percentage.to_f.round(2), 100].min %>%"></div>
-                  </div>
-                </div>
-              <% end %>
-            </div>
-          <% else %>
-            <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-gray-600">
-              Nenhuma alocacao por subcategoria disponivel para este portfolio.
-            </div>
-          <% end %>
+                <% end %>
+              </div>
+            <% else %>
+              <div class="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-gray-600">
+                Nenhuma alocacao por subcategoria disponivel para este portfolio.
+              </div>
+            <% end %>
+          </details>
         </div>
       </div>
     </div>

--- a/docs/governance/issue-68-implementation-plan.md
+++ b/docs/governance/issue-68-implementation-plan.md
@@ -1,0 +1,70 @@
+# Issue 68 Implementation Plan
+
+## Objective
+
+Improve dashboard usability by allowing users to filter analytics data on the portfolio dashboard.
+
+The first iteration will support:
+
+- portfolio context through the current portfolio show page
+- date range filtering
+- asset category filtering
+
+## Affected Files
+
+- `app/controllers/investments/portfolios_controller.rb`
+- `app/services/investments/portfolio_dashboard_builder.rb`
+- `app/views/investments/portfolios/show.html.erb`
+- `spec/services/investments/portfolio_dashboard_builder_spec.rb`
+- `spec/requests/investments/portfolios_spec.rb`
+- `docs/code-overview.md`
+
+## Risks
+
+- Applying filters inconsistently across summary cards, allocations, positions, and historical evolution
+- Accidentally filtering the wrong dataset, especially mixing transaction dates with current open positions
+- Breaking dashboard navigation by losing filter state between requests
+- Adding controller logic that becomes too coupled to dashboard calculation details
+
+## Technical Strategy
+
+Introduce an explicit dashboard filter object at the controller boundary and pass normalized filter values into `Investments::PortfolioDashboardBuilder`.
+
+Planned filters:
+
+- `from_date`
+- `to_date`
+- `category`
+
+Filtering behavior:
+
+- transactions used for historical evolution, current positions, and recent activity should respect the selected date range
+- asset/category summaries should only reflect the filtered transaction universe
+- category filtering should limit dashboard calculations to assets in the selected category
+- income summaries should be aligned with the selected date range and category whenever possible
+
+The UI should:
+
+- expose a compact filter form at the top of the dashboard
+- preserve filter state in the query string
+- allow users to clear filters easily
+
+## Database Impact
+
+No schema changes are required.
+
+The implementation should rely on scoped queries over existing portfolios, transactions, incomes, and assets.
+
+## Required Tests
+
+- service specs covering date range filtering
+- service specs covering category filtering
+- service specs proving filtered summaries remain internally consistent
+- request specs covering dashboard rendering with filters applied
+- request specs proving filter state is preserved in navigation
+
+## Approval
+
+- status: approved
+- approved by: user
+- approval date: 2026-07-16

--- a/spec/requests/investments/portfolios_spec.rb
+++ b/spec/requests/investments/portfolios_spec.rb
@@ -141,6 +141,43 @@ RSpec.describe "Investments::Portfolios", type: :request do
       expect(response.body).to include("Sem subcategoria")
     end
 
+    it "filters dashboard data by category and preserves selected filters" do
+      get investments_portfolio_path(portfolio), params: { category: "stock" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Banco do Brasil")
+      expect(response.body).not_to include("Apple Inc.")
+      expect(response.body).to include('option selected="selected" value="stock"')
+    end
+
+    it "filters dashboard data by date range and preserves date fields" do
+      older_only_asset = Investments::Asset.create!(
+        name: "Old Position",
+        symbol: "OLD1",
+        category: :stock,
+        currency: "BRL"
+      )
+
+      Investments::Transaction.create!(
+        portfolio: portfolio,
+        asset: older_only_asset,
+        transaction_type: :buy,
+        quantity: 3,
+        price: 12,
+        fees: 0,
+        date: Date.new(2026, 1, 10)
+      )
+
+      get investments_portfolio_path(portfolio), params: {
+        from_date: Date.current.to_s,
+        to_date: Date.current.to_s
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Old Position")
+      expect(response.body).to include(%(value="#{Date.current}"))
+    end
+
     it "returns not found for a portfolio from another user" do
       other_user = User.create!(
         name: "Another User",

--- a/spec/services/investments/portfolio_dashboard_builder_spec.rb
+++ b/spec/services/investments/portfolio_dashboard_builder_spec.rb
@@ -238,6 +238,54 @@ RSpec.describe Investments::PortfolioDashboardBuilder do
     expect(dashboard.asset_entries.first.quantity).to eq(BigDecimal("2"))
   end
 
+  it "filters dashboard calculations by category" do
+    fixed_income_asset = Investments::Asset.create!(
+      name: "Tesouro Selic",
+      symbol: "SELIC2029",
+      category: :fixed_income,
+      currency: "BRL"
+    )
+
+    create_transaction(stock_asset, :buy, quantity: 2, price: 10, date: Date.new(2026, 1, 1))
+    create_transaction(fii_asset, :buy, quantity: 5, price: 10, date: Date.new(2026, 1, 2))
+    create_transaction(fixed_income_asset, :buy, quantity: 3, price: 20, date: Date.new(2026, 1, 3))
+    create_income(stock_asset, net_amount: 15, gross_amount: 15, tax_amount: 0)
+    create_income(fii_asset, net_amount: 25, gross_amount: 25, tax_amount: 0)
+
+    filtered_dashboard = described_class.call(
+      portfolio: portfolio,
+      price_lookup_service: price_lookup_service,
+      category: "fii"
+    )
+
+    expect(filtered_dashboard.asset_entries.map { |entry| entry.asset.symbol }).to eq(["XPML11"])
+    expect(filtered_dashboard.total_invested_amount).to eq(BigDecimal("50"))
+    expect(filtered_dashboard.passive_income_summary).to eq(BigDecimal("25"))
+    expect(filtered_dashboard.category_allocations.map(&:category)).to eq(["fii"])
+  end
+
+  it "filters dashboard calculations by date range" do
+    create_transaction(stock_asset, :buy, quantity: 2, price: 10, date: Date.new(2026, 1, 1))
+    create_transaction(fii_asset, :buy, quantity: 5, price: 10, date: Date.new(2026, 2, 1))
+    create_transaction(stock_asset, :buy, quantity: 1, price: 12, date: Date.new(2026, 3, 1))
+    create_income(stock_asset, net_amount: 5, gross_amount: 5, tax_amount: 0, payment_date: Date.new(2026, 1, 15))
+    create_income(fii_asset, net_amount: 12, gross_amount: 12, tax_amount: 0, payment_date: Date.new(2026, 2, 15))
+
+    filtered_dashboard = described_class.call(
+      portfolio: portfolio,
+      price_lookup_service: price_lookup_service,
+      from_date: Date.new(2026, 2, 1),
+      to_date: Date.new(2026, 3, 1)
+    )
+
+    expect(filtered_dashboard.asset_entries.map { |entry| entry.asset.symbol }).to eq(%w[XPML11 AAPL])
+    expect(filtered_dashboard.total_invested_amount).to eq(BigDecimal("62"))
+    expect(filtered_dashboard.passive_income_summary).to eq(BigDecimal("12"))
+    expect(filtered_dashboard.historical_evolution_points.map(&:date)).to eq(
+      [Date.new(2026, 2, 1), Date.new(2026, 3, 1)]
+    )
+  end
+
   def create_transaction(asset, transaction_type, quantity:, price:, fees: 0, date: Date.new(2026, 1, 1), portfolio: self.portfolio)
     Investments::Transaction.create!(
       portfolio: portfolio,


### PR DESCRIPTION
## Summary
- adds dashboard filters for date range and asset category
- applies filters consistently across portfolio analytics
- preserves filter state through the dashboard URL
- refines the portfolio dashboard layout and interaction patterns

## What changed
- added normalized dashboard filter handling in `Investments::PortfoliosController`
- extended `Investments::PortfolioDashboardBuilder` to support:
  - `from_date`
  - `to_date`
  - `category`
- updated dashboard calculations so filters affect:
  - current positions
  - historical evolution
  - category allocations
  - subcategory allocations
  - passive income summary
  - recent transactions
- added a compact filter bar to the portfolio dashboard UI
- improved dashboard presentation by:
  - centering the main container correctly
  - moving the transactions button to the top-right area
  - shortening the market-value notice
  - showing current price before average price
  - color-coding current price against average price
  - making allocation sections collapsible and closed by default
  - removing edit/delete actions from the dashboard screen

## Validation
- `bundle exec rspec spec/services/investments/portfolio_dashboard_builder_spec.rb`
- `bundle exec rspec spec/requests/investments/portfolios_spec.rb`

## Notes
- date filters are applied to transaction-based and income-based dashboard sections
- category filters narrow the dashboard to assets within the selected category
- filter state is preserved in the query string